### PR TITLE
docs: rename further urls after migration of OpenUI5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ""
 This tracker is for issues caused by the tools maintained here (type definition generator and ts-interface generator for control development support).
 But if the bug is within the original OpenUI5/SAPUI5 code/JSDoc, then please report the issue there!
 
-Example: if a UI5 API is defined wrongly in the TypeScript type definitions but the same wrong definition can also be found in the [UI5 API documentation](https://ui5.sap.com), then the issue originates probably from the JSDoc inside the UI5 code, from which both are generated, and needs to be reported in the [OpenUI5 issue tracker](https://github.com/SAP/openui5/issues/new) or the one for SAPUI5, respectively.
+Example: if a UI5 API is defined wrongly in the TypeScript type definitions but the same wrong definition can also be found in the [UI5 API documentation](https://ui5.sap.com), then the issue originates probably from the JSDoc inside the UI5 code, from which both are generated, and needs to be reported in the [OpenUI5 issue tracker](https://github.com/UI5/openui5/issues/new) or the one for SAPUI5, respectively.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This is managed automatically via https://cla-assistant.io/ pull request voter.
 
 As artificial intelligence evolves, AI-generated code is becoming valuable for many software projects, including open-source initiatives. While we recognize the potential benefits of incorporating AI-generated content into our open-source projects there are certain requirements that need to be reflected and adhered to when making contributions.
 
-Please see our [guideline for AI-generated code contributions to SAP Open Source Software Projects](https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md) for these requirements.
+Please see our [guideline for AI-generated code contributions to SAP Open Source Software Projects](https://github.com/UI5/.github/blob/main/CONTRIBUTING_USING_GENAI.md) for these requirements.
 
 ## Development Environment
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [demos](./demos) directory for consumption examples of the legacy signat
 ## Support
 
 For issues caused by the generators please open [issues](https://github.com/UI5/typescript/issues) on GitHub.<br>
-However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/SAP/openui5/issues)/SAPUI5 ticket in this case.
+However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/UI5/openui5/issues)/SAPUI5 ticket in this case.
 
 ## Contributing
 

--- a/packages/dts-generator/CONTRIBUTING.md
+++ b/packages/dts-generator/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please read the shared [mono-repo contribution](../../CONTRIBUTING.md) guide fir
 ## Issue Reporting
 
 For problems caused by the transformation process implemented in this dts-generator, please open [issues](https://github.com/UI5/typescript/issues) in this repository on GitHub.<br>
-However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/SAP/openui5/issues)/SAPUI5 ticket in this case.
+However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/UI5/openui5/issues)/SAPUI5 ticket in this case.
 
 ## SAPUI5 Integration
 

--- a/packages/dts-generator/README.md
+++ b/packages/dts-generator/README.md
@@ -221,7 +221,7 @@ The last block which may be unexpected at first sight is for providing code comp
 ## Support
 
 For problems caused by the transformation process implemented in this dts-generator, please open [issues](https://github.com/UI5/typescript/issues) in this repository on GitHub.<br>
-However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/SAP/openui5/issues)/SAPUI5 ticket in this case.
+However, issues in the UI5 type definitions which are also present in the [API documentation](https://ui5.sap.com/#/api) originate from the JSDoc comments in the original OpenUI5/SAPUI5 code, so please directly open an [OpenUI5](https://github.com/UI5/openui5/issues)/SAPUI5 ticket in this case.
 
 ## Contributing
 

--- a/packages/dts-generator/docs/end-to-end-sample.md
+++ b/packages/dts-generator/docs/end-to-end-sample.md
@@ -64,7 +64,7 @@ When the build has completed, the `api.json` file is at `dist/test-resources/com
 
 This file is the API description used not only for the type generation, but also for the API documentation in the UI5 SDK.
 
-**NOTE:** To get proper content, you must maintain the JSDoc in the JavaScript sources correctly. This is not always trivial. You can find instructions at https://github.com/SAP/openui5/blob/master/docs/guidelines/jsdoc.md and in sibling files.
+**NOTE:** To get proper content, you must maintain the JSDoc in the JavaScript sources correctly. This is not always trivial. You can find instructions at https://github.com/UI5/openui5/blob/master/docs/guidelines/jsdoc.md and in sibling files.
 
 The TypeScript type definitions only contain the public API of the library, so entities which are not marked as public will not be available.
 

--- a/packages/dts-generator/src/checkDtslint/check-dtslint.ts
+++ b/packages/dts-generator/src/checkDtslint/check-dtslint.ts
@@ -141,7 +141,7 @@ const MIN_TYPESCRIPT_VERSION_LINES = `/**
 *
 * These *.d.ts files are generated. In case of issues, either the generator or the JSDoc in the original
 * OpenUI5 repository must be fixed. The generator is developed at https://github.com/UI5/typescript/tree/main/packages/dts-generator
-* and you can contribute to OpenUI5, see: https://github.com/SAP/openui5/blob/master/CONTRIBUTING.md
+* and you can contribute to OpenUI5, see: https://github.com/UI5/openui5/blob/master/CONTRIBUTING.md
 */
 
 /// <reference types="jquery" />

--- a/packages/dts-generator/src/checkDtslint/dtslintConfig/package.json
+++ b/packages/dts-generator/src/checkDtslint/dtslintConfig/package.json
@@ -5,7 +5,7 @@
   "nonNpm": true,
   "nonNpmDescription": "openui5",
   "projects": [
-    "https://github.com/SAP/openui5"
+    "https://github.com/UI5/openui5"
   ],
   "minimumTypeScriptVersion": "5.0",
   "dependencies": {

--- a/packages/dts-generator/src/js-utils/ui5-metadata.js
+++ b/packages/dts-generator/src/js-utils/ui5-metadata.js
@@ -199,8 +199,8 @@ export async function downloadDtsgenrcFiles(
   }
 
   // GitHub libraries (example URL):
-  // https://raw.githubusercontent.com/SAP/openui5/${version}/src/sap.m/.dtsgenrc
-  const baseUrl = `https://raw.githubusercontent.com/SAP/openui5/${version}/src/`;
+  // https://raw.githubusercontent.com/UI5/openui5/${version}/src/sap.m/.dtsgenrc
+  const baseUrl = `https://raw.githubusercontent.com/UI5/openui5/${version}/src/`;
   const libraryNameToDtsgenrcFileUrl = zipObject(
     libs,
     map(libs, (_) => `${baseUrl}${_}/.dtsgenrc`),

--- a/packages/ts-interface-generator/src/collectClassInfo.ts
+++ b/packages/ts-interface-generator/src/collectClassInfo.ts
@@ -15,7 +15,7 @@ const mSingular: { [key: string]: string | number } = {
 
 function collectClassInfo(metadata: ClassInfo, className: string) {
   // !!!
-  // Mostly rewritten in TypeScript based on lines 732-988 in https://github.com/SAP/openui5/blob/ff8dec90ff0591e10f8bac1754a622f5d522a957/lib/jsdoc/ui5/plugin.js#L732-L988
+  // Mostly rewritten in TypeScript based on lines 732-988 in https://github.com/UI5/openui5/blob/ff8dec90ff0591e10f8bac1754a622f5d522a957/lib/jsdoc/ui5/plugin.js#L732-L988
   // hence still containing commented-out traces of that JS code.
   // Also, this is the reason why this code is structured and written like it is and may contain unneeded parts.
 

--- a/packages/ts-interface-generator/src/jsdocGenerator.ts
+++ b/packages/ts-interface-generator/src/jsdocGenerator.ts
@@ -1,6 +1,6 @@
 import Preferences from "./preferences";
 
-// converted to TypeScript after copying from https://github.com/SAP/openui5/blob/b21d5c95cbba5a6ad455a9276659e4698bc7421a/lib/jsdoc/ui5/plugin.js#L1618-L2307
+// converted to TypeScript after copying from https://github.com/UI5/openui5/blob/b21d5c95cbba5a6ad455a9276659e4698bc7421a/lib/jsdoc/ui5/plugin.js#L1618-L2307
 // Then all type information stripped from the generated JSDoc, as well as visibility, @synthetic, @name, @function etc.
 // hungarian prefixing is removed as well
 


### PR DESCRIPTION
Follow-up of https://github.com/UI5/typescript/pull/512