### PR TITLE
fix(dts-generator): fix more derived type names for module:* classes

### DIFF
--- a/packages/dts-generator/src/phases/json-fixer.ts
+++ b/packages/dts-generator/src/phases/json-fixer.ts
@@ -20,7 +20,7 @@ import {
 import { TypeParser } from "../utils/type-parser.js";
 import { TSASTTypeBuilder } from "../utils/ts-ast-type-builder.js";
 import { addConstructorSettingsInterfaces } from "../utils/json-constructor-settings-interfaces.js";
-import { splitName } from "../utils/base-utils.js";
+import { calculateDerivedNames, splitName } from "../utils/base-utils.js";
 import { Directives } from "../generate-from-objects.js";
 import { addEventParameterInterfaces } from "../utils/json-event-parameter-interfaces.js";
 
@@ -452,12 +452,7 @@ function determineMissingExportsForTypes(symbols: ConcreteSymbol[]) {
 
   function basename(fqn: string) {
     // Note: this differs from splitName(fqn)[0] as it handles module:* namepaths
-    if (fqn.startsWith("module:")) {
-      const p = fqn.lastIndexOf("/");
-      fqn = fqn.slice(p + 1);
-    }
-    const p = fqn.lastIndexOf(".");
-    return fqn.slice(p + 1);
+    return calculateDerivedNames(fqn).basename;
   }
 
   symbols.forEach((symbol) => {
@@ -481,12 +476,13 @@ function determineMissingExportsForTypes(symbols: ConcreteSymbol[]) {
     } else {
       // non-canonical names need to be reported at least
       // TODO consumers need some documentation about the necessary imports (SDK enhancement?)
+      const { exportName } = calculateDerivedNames(symbol.name);
       log.warn(
         `**** symbol ${symbol.name} exported from "${
           symbol.module
-        }" as "${basename(symbol.name)}"`,
+        }" as "${exportName}"`,
       );
-      symbol.export = basename(symbol.name);
+      symbol.export = exportName;
     }
   });
 }

--- a/packages/dts-generator/src/utils/base-utils.ts
+++ b/packages/dts-generator/src/utils/base-utils.ts
@@ -2,3 +2,82 @@ export function splitName(name: string, separator = ".") {
   const p = name.lastIndexOf(separator);
   return p < 0 ? ["", name] : [name.slice(0, p), name.slice(p + 1)];
 }
+
+/*
+ * Calculates a derived name from an entity name by first calculating the basename
+ * of the entity, then applying the given `createDerivedBasename` transformation and
+ * then building a qualified name again from it.
+ *
+ * The returned object contains the fully qualified name `name`, the derived `basename`
+ * and the assumed `exportName` under which the derived entity is exported from the
+ * containing module.
+ *
+ * Examples (based on the $<Entity>Settings transformation):
+ * (1) sap.m.Button -->
+ *       name: "sap.m.$ButtonSettings"
+ *       basename: "$ButtonSettings"
+ *       exportName: "$ButtonSettings"
+ *
+ * (2) module:my/lib//NotificationListGroupItem -->
+ *       name: "module:my/lib/NotificationListGroupItem.$NotificationListGroupItemSettings"
+ *       basename: "$NotificationListGroupItemSettings"
+ *       exportName: "$NotificationListGroupItemSettings"
+ *
+ * (3) module:my/lib/SegmentedButton.Item
+ *       name: "module:my/lib/SegmentedButton.$ItemSettings"
+ *       basename: "$ItemSettings"
+ *       exportName: "$ItemSettings"
+ *
+ * (4) module:my/lib/SegmentedButton.Item.SubItem
+ *       name: "module:my/lib/SegmentedButton.Item.$SubItemSettings"
+ *       basename: "$SubItemSettings"
+ *       exportName: "Item.$SubItemSettings"
+ */
+export function calculateDerivedNames(
+  fqn: string,
+  createDerivedBasename: (basename: string) => string = (basename) => basename,
+): {
+  name: string;
+  basename: string;
+  exportName: string;
+} {
+  const makeNameAndBasename = (fqn: string) => {
+    const [prefix, basename] = splitName(fqn);
+    const derivedBasename = createDerivedBasename(basename);
+    return [`${prefix}${prefix ? "." : ""}${derivedBasename}`, derivedBasename];
+  };
+
+  if (fqn.startsWith("module:")) {
+    const [pkgname, moduleAndExport] = splitName(
+      fqn.slice("module:".length),
+      "/",
+    );
+    const pos = moduleAndExport.indexOf(".");
+    if (pos < 0) {
+      // case (2), default export
+      const [, settingsName] = makeNameAndBasename(moduleAndExport);
+      return {
+        name: `${fqn}.${settingsName}`,
+        basename: settingsName,
+        exportName: settingsName,
+      };
+    }
+    // case (3) and (4), named export
+    const moduleBaseName = moduleAndExport.slice(0, pos);
+    const exportName = moduleAndExport.slice(pos + 1);
+    const [settingsNameWithPrefix, settingsName] =
+      makeNameAndBasename(exportName);
+    return {
+      name: `module:${pkgname}${pkgname ? "/" : ""}${moduleBaseName}.${settingsNameWithPrefix}`,
+      basename: settingsName,
+      exportName: settingsNameWithPrefix,
+    };
+  }
+  // case (1), global name
+  const [fqSettingsName, settingsName] = makeNameAndBasename(fqn);
+  return {
+    name: fqSettingsName,
+    basename: settingsName,
+    exportName: settingsName,
+  };
+}


### PR DESCRIPTION
When a managed object class has a module:* name, the names are now correctly split into prefix and base name when calculating the name of the EventParameters and EventType types.

The implementation of the calculations is now shared with the calculation implemented in b6c0fe52c1603042439df035b5ba8f5439b732f8.