### PR TITLE
fix(ts-interface-generator): support classes inheriting from generic base classes

### DIFF
--- a/packages/ts-interface-generator/src/interfaceGenerationHelper.ts
+++ b/packages/ts-interface-generator/src/interfaceGenerationHelper.ts
@@ -562,7 +562,17 @@ function getInterestingBaseClass(
     return interestingBaseClass;
   }
   if (!type.isClassOrInterface()) {
-    return;
+    // Handle instantiated generic types like MyGenericClass<SomeType>
+    // For these, isClassOrInterface() returns false, but the target property
+    // contains the original generic class definition
+    if (
+      (type as ts.TypeReference).target &&
+      (type as ts.TypeReference).target.isClassOrInterface()
+    ) {
+      type = (type as ts.TypeReference).target;
+    } else {
+      return;
+    }
   }
   const baseTypes = typeChecker.getBaseTypes(type);
   for (let i = 0; i < baseTypes.length; i++) {
@@ -592,11 +602,19 @@ function getInterestingBaseSettingsClass(
   | undefined {
   const symbol = type.getSymbol();
   if (!symbol) {
+    // Handle instantiated generic types - try to use the target type
+    if ((type as ts.TypeReference).target) {
+      return getInterestingBaseSettingsClass(
+        (type as ts.TypeReference).target,
+        typeChecker,
+      );
+    }
     log.error(`Symbol ${
       type.aliasSymbol ? `for type '${type.aliasSymbol.getName()}'` : ""
     } could not be resolved.
     This means that TypeScript did not find out what this type actually is.
     Check the source code: is this type defined where it is written? If not, why not?`);
+    return;
   }
   let interestingBaseSettingsClass =
     interestingBaseSettingsClasses[typeChecker.getFullyQualifiedName(symbol)];


### PR DESCRIPTION
## Problem

When a class inherits from a **generic base class** (e.g., `MyBaseClass<T>`), the `@ui5/ts-interface-generator` skips the class entirely and does not generate a `.gen.d.ts` file.

### Root Cause

TypeScript's `type.isClassOrInterface()` returns `false` for **instantiated generic types**. For example:

- `Control` → `isClassOrInterface()` returns `true` ✅
- `GenericControl<string>` → `isClassOrInterface()` returns `false` ❌

The generator's `getInterestingBaseClass()` and `getInterestingBaseSettingsClass()` functions currently return early when `isClassOrInterface()` is `false`, causing all classes inheriting from generic base classes to be skipped.

## Solution

For instantiated generic types, TypeScript stores the original generic class definition in the `target` property of the `TypeReference`. This fix checks for this property and uses it to continue the inheritance chain resolution.

## Reproduction Example

```typescript
import Control from "sap/ui/core/Control";
import type { MetadataOptions } from "sap/ui/core/Element";

// Generic base class extending a UI5 class
class GenericControl<T> extends Control {
  static readonly metadata: MetadataOptions = {
    properties: {
      value: { type: "object" }
    }
  };
}

/**
 * @namespace my.app.control
 */
export default class MyControl extends GenericControl<string> {
  static readonly metadata: MetadataOptions = {
    properties: {
      name: { type: "string", defaultValue: "" }
    }
  };
}
```

**Before this fix:** No `MyControl.gen.d.ts` is generated, no accessor methods like `getName()` / `setName()` are typed.

**After this fix:** `MyControl.gen.d.ts` is generated correctly with all typed accessor methods.

## Changes

- `getInterestingBaseClass()`: When `isClassOrInterface()` returns `false`, check if `type.target` exists and is a class/interface, then use that for inheritance resolution.
- `getInterestingBaseSettingsClass()`: Same approach - when `symbol` is `null`, check `type.target` and recursively resolve.

## Testing

Tested with a custom UI5 library containing generic base classes. All subclasses now correctly generate `.gen.d.ts` files.