### PR TITLE
fix(ts-interface-generator): properly type getters for properties of type `object` and `function` 

### DIFF
--- a/packages/ts-interface-generator/src/astGenerationHelper.ts
+++ b/packages/ts-interface-generator/src/astGenerationHelper.ts
@@ -1090,7 +1090,10 @@ function createTSTypeNode(
       );
 
     case "object":
-      return factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword);
+      return factory.createUnionTypeNode([
+        factory.createKeywordTypeNode(ts.SyntaxKind.ObjectKeyword),
+        factory.createLiteralTypeNode(factory.createNull()),
+      ]);
 
     case "object[]":
       return factory.createArrayTypeNode(
@@ -1098,9 +1101,10 @@ function createTSTypeNode(
       );
 
     case "function":
-      return factory.createTypeReferenceNode(
-        factory.createIdentifier("Function"),
-      );
+      return factory.createUnionTypeNode([
+        factory.createTypeReferenceNode(factory.createIdentifier("Function")),
+        factory.createLiteralTypeNode(factory.createNull()),
+      ]);
 
     case "function[]":
       return factory.createArrayTypeNode(


### PR DESCRIPTION
For types like `object` or `function` the default value was/is not respected when generating accessors. The getter would/is wrongly typed when no callbacks/fns are provided to control properties.

So that a definition of
`someFunc: { type: "function", group: "Behavior", defaultValue: null }`

correctly generates :
`getSomeFunc(): Function | null;`

instead of:
`getSomeFunc(): Function` 

I'm not that deep in the code base but have noticed that not all types have tests (though, I patched this locally in a project of mine so ... it works) and also that this change could maybe live somewhere in `function generateMethods`. Cases like [this one](https://github.com/UI5/openui5/blob/52f8e6d1adfb7ff4b6e879442e4c2ce58663c359/src/sap.m/src/sap/m/upload/UploadItemConfiguration.js#L74), albeit a rather unusual one, would not be covered today (probably rather a wrong definition in UI5 itself and thus user/dev error more more than anything else).

Some more examples of similar definitions within UI5 ...
- https://github.com/UI5/openui5/blob/52f8e6d1adfb7ff4b6e879442e4c2ce58663c359/src/sap.m/src/sap/m/upload/FilePreviewDialog.js#L134
- https://github.com/UI5/openui5/blob/52f8e6d1adfb7ff4b6e879442e4c2ce58663c359/src/sap.m/src/sap/m/MessagePopover.js#L120