### PR TITLE
feat(dts-generator): trust source data for event parameter optionality

### DIFF
--- a/.changeset/event-param-optionality.md
+++ b/.changeset/event-param-optionality.md
@@ -1,0 +1,5 @@
+---
+"@ui5/dts-generator": minor
+---
+
+Event parameter interfaces now reflect actual optionality from the UI5 source data. Previously all event parameters were unconditionally generated as optional (`?`); now parameters marked `optional: false` in the API are generated as required. A new `eventsWithAllParamsOptional` directive in `.dtsgenrc` lets you preserve the legacy all-optional behavior for specific events whose optionality hasn't been verified upstream yet.

--- a/packages/dts-generator/api-report/dts-generator.api.md
+++ b/packages/dts-generator/api-report/dts-generator.api.md
@@ -42,6 +42,7 @@ export interface Directives {
     deprecatedEnumAliases: {
         [fqn: string]: string;
     };
+    eventsWithAllParamsOptional?: string[];
     forwardDeclarations: {
         [libraryName: string]: ConcreteSymbol[];
     };

--- a/packages/dts-generator/src/generate-from-objects.ts
+++ b/packages/dts-generator/src/generate-from-objects.ts
@@ -103,6 +103,13 @@ export interface Directives {
    * to be listed.
    */
   modulesWithNamedExports: string[];
+
+  /**
+   * Events listed here retain the legacy "all parameters optional" behavior.
+   * Format: "fully.qualified.ClassName:eventName"
+   * Used for events whose parameter optionality has not yet been verified in the source.
+   */
+  eventsWithAllParamsOptional?: string[];
 }
 
 /**
@@ -145,6 +152,7 @@ const defaultOptions: GenerateFromObjectsConfig = {
     overlays: {},
     deprecatedEnumAliases: {},
     modulesWithNamedExports: [],
+    eventsWithAllParamsOptional: [],
   },
   generateGlobals: false,
 };

--- a/packages/dts-generator/src/generate.ts
+++ b/packages/dts-generator/src/generate.ts
@@ -35,6 +35,7 @@ async function loadDirectives(directivesPaths: string[]) {
     overlays: {},
     deprecatedEnumAliases: {},
     modulesWithNamedExports: [],
+    eventsWithAllParamsOptional: [],
   };
 
   function mergeDirectives(loadedDirectives: Directives) {

--- a/packages/dts-generator/src/phases/json-fixer.ts
+++ b/packages/dts-generator/src/phases/json-fixer.ts
@@ -49,7 +49,7 @@ function mergeOverlays(
     );
   }
 
-  const mapLikeProperties = new Set(["methods", "properties"]);
+  const mapLikeProperties = new Set(["methods", "properties", "events"]);
 
   function mergeProp(
     obj: { [key: string]: unknown },
@@ -984,7 +984,7 @@ export function fixApiJsons(
 
   // Part 2: add interfaces for settings objects and event parameter objects
   addConstructorSettingsInterfaces(targetLibFixedJson, depsFixedJsons);
-  addEventParameterInterfaces(targetLibFixedJson, depsFixedJsons);
+  addEventParameterInterfaces(targetLibFixedJson, depsFixedJsons, directives);
 
   // Part 3: "fix JSON"
   targetLibFixedJson = _fixApiJson(targetLibFixedJson, directives.badSymbols);

--- a/packages/dts-generator/src/utils/json-event-parameter-interfaces.ts
+++ b/packages/dts-generator/src/utils/json-event-parameter-interfaces.ts
@@ -4,11 +4,12 @@ import {
   ClassSymbol,
   ConcreteSymbol,
   InterfaceSymbol,
+  NestedProperties,
   ObjCallableParameter,
   TypedefSymbol,
   Ui5Event,
 } from "../types/api-json.js";
-const log = getLogger("@ui5/dts-generator/constructor-settings-interfaces");
+const log = getLogger("@ui5/dts-generator/event-parameter-interfaces");
 import { calculateDerivedNames } from "./base-utils.js";
 import {
   addJsDocProps,
@@ -16,6 +17,7 @@ import {
   makeSettingsNames,
 } from "./json-constructor-settings-interfaces.js";
 import { FunctionType, TypeReference } from "../types/ast.js";
+import { Directives } from "../generate-from-objects.js";
 
 /**
  * Creates for each event in an `EventProvider` subclass an interface that describes the
@@ -40,6 +42,7 @@ function createEventParameterInterfaces(
   symbols: ConcreteSymbol[],
   dependencies: ApiJSON[],
   addDetails: boolean,
+  directives?: Directives,
 ) {
   const typeUniverse = new Map();
 
@@ -71,20 +74,32 @@ function createEventParameterInterfaces(
     };
   };
 
-  function buildProperties(srcProperties) {
+  function buildProperties(
+    srcProperties: NestedProperties,
+    allOptional: boolean,
+    context: string,
+  ) {
     const transformedProperties = [];
     for (let propertyName in srcProperties) {
       const prop = srcProperties[propertyName];
-      transformedProperties.push(
-        addJsDocProps(
-          {
-            name: prop.name,
-            type: prop.type,
-            visibility: "public", // prop.visibility,
-          },
-          prop,
-        ),
+      const transformed = addJsDocProps(
+        {
+          name: prop.name,
+          type: prop.type,
+          visibility: "public", // prop.visibility,
+        },
+        prop,
       );
+      if (!allOptional) {
+        if (prop.optional === false) {
+          transformed.optional = false;
+        } else if (prop.optional !== true) {
+          log.warn(
+            `Event parameter "${prop.name}" in ${context} has no "optional" value; treating as optional.`,
+          );
+        }
+      }
+      transformedProperties.push(transformed);
     }
     return transformedProperties;
   }
@@ -118,7 +133,9 @@ function createEventParameterInterfaces(
           superEvent: superEvents[0],
         };
       } else if (superEvents && superEvents.length > 1) {
-        debugger; // should never happen
+        log.warn(
+          `Multiple events named "${eventName}" found on superclass ${superClassSymbol.name}`,
+        );
       } else {
         // superclass does not have the event -> go up the class hierarchy
         superClassSymbol = nextEventProviderSuperClass(superClassSymbol);
@@ -270,12 +287,12 @@ function createEventParameterInterfaces(
           };
 
           // collect parameters
-          const allParameters =
+          const allParameters: NestedProperties =
             (addDetails &&
               event.parameters &&
               (event.parameters[0] as ObjCallableParameter).parameterProperties
                 ?.getParameters?.parameterProperties) ||
-            [];
+            {};
           const hasParameters = Object.keys(allParameters).length > 0; // remember because elements from allParameters are removed below; if true, then at least somesuperclass has parameters
 
           // search superclasses for same event
@@ -320,7 +337,15 @@ function createEventParameterInterfaces(
           }
 
           // now add the parameters to the interface
-          const parameters = buildProperties(allParameters);
+          const allOptional =
+            directives?.eventsWithAllParamsOptional?.includes(
+              `${symbol.name}:${event.name}`,
+            ) ?? false;
+          const parameters = buildProperties(
+            allParameters,
+            allOptional,
+            `${symbol.name}#${event.name}`,
+          );
           eventParametersInterface.properties = parameters;
           eventParametersInterface.description = `Parameters of the ${symbol.basename}#${event.name} event.`;
           if (event.deprecated) {
@@ -418,9 +443,20 @@ function createEventParameterInterfaces(
 export function addEventParameterInterfaces(
   apijson: ApiJSON,
   dependencies: ApiJSON[],
+  directives?: Directives,
 ) {
   dependencies.forEach((dep) => {
-    createEventParameterInterfaces(dep.symbols, dependencies, false);
+    createEventParameterInterfaces(
+      dep.symbols,
+      dependencies,
+      false,
+      directives,
+    );
   });
-  createEventParameterInterfaces(apijson.symbols, dependencies, true);
+  createEventParameterInterfaces(
+    apijson.symbols,
+    dependencies,
+    true,
+    directives,
+  );
 }

--- a/test-packages/openui5-snapshot-test/output-dts/sap.f.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.f.d.ts
@@ -973,17 +973,17 @@ declare module "sap/f/AvatarGroup" {
     /**
      * The `GroupType` of the control.
      */
-    groupType?: string;
+    groupType: string;
 
     /**
      * Indication whether the overflow button is pressed.
      */
-    overflowButtonPressed?: boolean;
+    overflowButtonPressed: boolean;
 
     /**
      * The number of currently displayed (visible) avatars.
      */
-    avatarsDisplayed?: int;
+    avatarsDisplayed: int;
   }
 
   /**
@@ -5006,7 +5006,7 @@ declare module "sap/f/DynamicPage" {
     /**
      * False or True values indicate the new pinned property value.
      */
-    pinned?: boolean;
+    pinned: boolean;
   }
 
   /**
@@ -6893,7 +6893,7 @@ declare module "sap/f/DynamicPageTitle" {
     /**
      * Whether the title was expanded (true) or collapsed (false).
      */
-    isExpanded?: boolean;
+    isExpanded: boolean;
   }
 
   /**
@@ -9036,53 +9036,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which had been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which had been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page, which has been navigated to)
      * has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether was a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9100,53 +9100,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which had been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which had been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page, which has been navigated to)
      * has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether was a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9164,53 +9164,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which had been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which had been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page, which has been navigated to)
      * has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether was a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9228,53 +9228,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which is currently
      * being navigated to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9292,17 +9292,17 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * Determines whether `beginColumn` resize has completed.
      */
-    beginColumn?: boolean;
+    beginColumn: boolean;
 
     /**
      * Determines whether `midColumn` resize has completed.
      */
-    midColumn?: boolean;
+    midColumn: boolean;
 
     /**
      * Determines whether `endColumn` resize has completed.
      */
-    endColumn?: boolean;
+    endColumn: boolean;
   }
 
   /**
@@ -9320,53 +9320,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which is currently
      * being navigated to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9384,53 +9384,53 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The page, which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which is currently
      * being navigated to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -9448,7 +9448,7 @@ declare module "sap/f/FlexibleColumnLayout" {
     /**
      * The value of the `layout` property
      */
-    layout?: LayoutType | keyof typeof LayoutType;
+    layout: LayoutType | keyof typeof LayoutType;
 
     /**
      * The maximum number of columns that can be displayed at once based on the available screen size and control
@@ -9459,17 +9459,17 @@ declare module "sap/f/FlexibleColumnLayout" {
      * 	 - 2 for browser size between 960px and 1280px
      * 	 - 1 for browser size less than 960px
      */
-    maxColumnsCount?: int;
+    maxColumnsCount: int;
 
     /**
      * Indicates whether the layout changed as a result of the user clicking a layout arrow
      */
-    isNavigationArrow?: boolean;
+    isNavigationArrow: boolean;
 
     /**
      * Indicates whether the maximum number of columns that can be displayed at once changed
      */
-    isResize?: boolean;
+    isResize: boolean;
   }
 
   /**
@@ -11300,22 +11300,22 @@ declare module "sap/f/GridContainer" {
     /**
      * Event that leads to the focus change.
      */
-    event?: jQuery.Event;
+    event: jQuery.Event;
 
     /**
      * The navigation direction that is used to reach the border.
      */
-    direction?: NavigationDirection | keyof typeof NavigationDirection;
+    direction: NavigationDirection | keyof typeof NavigationDirection;
 
     /**
      * The row index, from which the border is reached.
      */
-    row?: int;
+    row: int;
 
     /**
      * The column index, from which the border is reached.
      */
-    column?: int;
+    column: int;
   }
 
   /**
@@ -11333,7 +11333,7 @@ declare module "sap/f/GridContainer" {
     /**
      * The count of the gird columns.
      */
-    columns?: int;
+    columns: int;
   }
 
   /**
@@ -11351,7 +11351,7 @@ declare module "sap/f/GridContainer" {
     /**
      * The name of the newly active layout.
      */
-    layout?: string;
+    layout: string;
   }
 
   /**
@@ -12207,22 +12207,22 @@ declare module "sap/f/GridList" {
     /**
      * Event that leads to the focus change.
      */
-    event?: jQuery.Event;
+    event: jQuery.Event;
 
     /**
      * The navigation direction that is used to reach the border.
      */
-    direction?: NavigationDirection | keyof typeof NavigationDirection;
+    direction: NavigationDirection | keyof typeof NavigationDirection;
 
     /**
      * The row index, from which the border is reached.
      */
-    row?: int;
+    row: int;
 
     /**
      * The the column index, from which the border is reached.
      */
-    column?: int;
+    column: int;
   }
 
   /**
@@ -12960,7 +12960,7 @@ declare module "sap/f/ProductSwitch" {
     /**
      * Reference to the new item that has been selected.
      */
-    itemPressed?: ProductSwitchItem;
+    itemPressed: ProductSwitchItem;
   }
 
   /**
@@ -14491,7 +14491,7 @@ declare module "sap/f/SearchManager" {
     /**
      * Current search string.
      */
-    newValue?: string;
+    newValue: string;
   }
 
   /**
@@ -14509,12 +14509,12 @@ declare module "sap/f/SearchManager" {
     /**
      * The search query string.
      */
-    query?: string;
+    query: string;
 
     /**
      * Indicates if the user pressed the clear icon.
      */
-    clearButtonPressed?: boolean;
+    clearButtonPressed: boolean;
   }
 
   /**
@@ -14532,7 +14532,7 @@ declare module "sap/f/SearchManager" {
     /**
      * Current search string of the search field.
      */
-    suggestValue?: string;
+    suggestValue: string;
   }
 
   /**
@@ -20695,7 +20695,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    avatar?: Avatar;
+    avatar: Avatar;
   }
 
   /**
@@ -20713,12 +20713,12 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    image?: Image;
+    image: Image;
 
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -20736,7 +20736,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the image that has been pressed
      */
-    icon?: Image;
+    icon: Image;
   }
 
   /**
@@ -20754,7 +20754,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -20772,7 +20772,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -20790,7 +20790,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -20808,7 +20808,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -20826,7 +20826,7 @@ declare module "sap/f/ShellBar" {
     /**
      * Reference to the button that has been pressed
      */
-    button?: Button;
+    button: Button;
   }
 
   /**
@@ -21640,12 +21640,12 @@ declare module "sap/f/SidePanel" {
     /**
      * The action item that triggers the event.
      */
-    item?: SidePanelItem;
+    item: SidePanelItem;
 
     /**
      * State of the action item.
      */
-    expanded?: boolean;
+    expanded: boolean;
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/output-dts/sap.m.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.m.d.ts
@@ -4817,7 +4817,7 @@ declare module "sap/m/ActionSheet" {
      * (on mobile device), the button that closes the dialog is set to this parameter. Otherwise this parameter
      * is set to null.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -4850,7 +4850,7 @@ declare module "sap/m/ActionSheet" {
      * the button that closes the dialog is set to this parameter. Otherwise this parameter is set to null.
      * This is valid only for Phone mode of the ActionSheet
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -5499,7 +5499,7 @@ declare module "sap/m/App" {
     /**
      * Whether the device is in landscape orientation.
      */
-    landscape?: boolean;
+    landscape: boolean;
   }
 
   /**
@@ -8671,7 +8671,7 @@ declare module "sap/m/BusyDialog" {
      * Indicates if the close events are triggered by a user, pressing a cancel button or because the operation
      * was terminated. This parameter is set to true if the close event is fired by user interaction.
      */
-    cancelPressed?: boolean;
+    cancelPressed: boolean;
   }
 
   /**
@@ -11114,7 +11114,7 @@ declare module "sap/m/Carousel" {
     /**
      * Indexes of all active pages after the page change.
      */
-    activePages?: any[];
+    activePages: any[];
   }
 
   /**
@@ -11134,7 +11134,7 @@ declare module "sap/m/Carousel" {
     /**
      * Id of the page which will be loaded
      */
-    pageId?: string;
+    pageId: string;
   }
 
   /**
@@ -11154,17 +11154,17 @@ declare module "sap/m/Carousel" {
     /**
      * ID of the page which was active before the page change.
      */
-    oldActivePageId?: string;
+    oldActivePageId: string;
 
     /**
      * ID of the page which will be active after the page change.
      */
-    newActivePageId?: string;
+    newActivePageId: string;
 
     /**
      * Indexes of all active pages after the page change.
      */
-    activePages?: any[];
+    activePages: any[];
   }
 
   /**
@@ -11184,7 +11184,7 @@ declare module "sap/m/Carousel" {
     /**
      * Id of the page which will be unloaded
      */
-    pageId?: string;
+    pageId: string;
   }
 
   /**
@@ -12256,7 +12256,7 @@ declare module "sap/m/CheckBox" {
     /**
      * Checks whether the CheckBox is marked or not .
      */
-    selected?: boolean;
+    selected: boolean;
   }
 
   /**
@@ -12614,12 +12614,12 @@ declare module "sap/m/ColorPalette" {
     /**
      * The color that is returned when user chooses the "Default color" button.
      */
-    value?: CSSColor;
+    value: CSSColor;
 
     /**
      * Denotes if the color has been chosen by selecting the "Default Color" button (true or false)
      */
-    defaultAction?: boolean;
+    defaultAction: boolean;
   }
 
   /**
@@ -12637,47 +12637,47 @@ declare module "sap/m/ColorPalette" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -13211,12 +13211,12 @@ declare module "sap/m/ColorPalettePopover" {
     /**
      * The selected color value.
      */
-    value?: CSSColor;
+    value: CSSColor;
 
     /**
      * Denotes if the color has been chosen by selecting the "Default Color" button (true or false).
      */
-    defaultAction?: boolean;
+    defaultAction: boolean;
   }
 
   /**
@@ -13234,47 +13234,47 @@ declare module "sap/m/ColorPalettePopover" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -15159,7 +15159,7 @@ declare module "sap/m/ComboBox" {
     /**
      * Indicates whether the change event was caused by selecting an item in the list
      */
-    itemPressed?: boolean;
+    itemPressed: boolean;
   }
 
   /**
@@ -15177,7 +15177,7 @@ declare module "sap/m/ComboBox" {
     /**
      * The selected item.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
   }
 
   /**
@@ -17804,7 +17804,7 @@ declare module "sap/m/DatePicker" {
     /**
      * Indicator for a valid date.
      */
-    valid?: boolean;
+    valid: boolean;
   }
 
   /**
@@ -17822,12 +17822,12 @@ declare module "sap/m/DatePicker" {
     /**
      * Date range containing the start and end date displayed in the `Calendar` popup.
      */
-    dateRange?: DateRange;
+    dateRange: DateRange;
 
     /**
      * Indicates if the event is fired, due to popup being opened.
      */
-    afterPopupOpened?: boolean;
+    afterPopupOpened: boolean;
   }
 
   /**
@@ -18254,12 +18254,12 @@ declare module "sap/m/DateRangeSelection" {
     /**
      * Current start date after change.
      */
-    from?: object;
+    from: object;
 
     /**
      * Current end date after change.
      */
-    to?: object;
+    to: object;
   }
 
   /**
@@ -18631,12 +18631,12 @@ declare module "sap/m/DateTimeField" {
     /**
      * The current value of the input, after a live change event.
      */
-    value?: string;
+    value: string;
 
     /**
      * The previous value of the input, before the last user interaction.
      */
-    previousValue?: string;
+    previousValue: string;
   }
 
   /**
@@ -19467,17 +19467,17 @@ declare module "sap/m/DateTimeInput" {
     /**
      * The string value of the control in given valueFormat (or locale format).
      */
-    value?: string;
+    value: string;
 
     /**
      * The value of control as JavaScript Date Object or null if value is empty.
      */
-    dateValue?: object;
+    dateValue: object;
 
     /**
      * if set, the entered value is a valid date. If not set the entered value cannot be converted to a date.
      */
-    valid?: boolean;
+    valid: boolean;
   }
 
   /**
@@ -21676,7 +21676,7 @@ declare module "sap/m/Dialog" {
      * or the `endButton`, the button that closes the Dialog is set to this parameter. Otherwise, the parameter
      * is set to `null`.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -21709,7 +21709,7 @@ declare module "sap/m/Dialog" {
      * or the `endButton`, the button that closes the Dialog is set to this parameter. Otherwise, the parameter
      * is set to `null`.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -23680,12 +23680,12 @@ declare module "sap/m/DynamicDateRange" {
     /**
      * The current value of the control.
      */
-    value?: object;
+    value: object;
 
     /**
      * Whether the new value is valid.
      */
-    valid?: boolean;
+    valid: boolean;
   }
 
   /**
@@ -26134,13 +26134,13 @@ declare module "sap/m/FacetFilterList" {
      * Array of selected items. Items returned are only copies and therefore can only be used to read properties,
      * not set them.
      */
-    selectedItems?: FacetFilterItem[];
+    selectedItems: FacetFilterItem[];
 
     /**
      * `True` if the select All checkbox is selected. This will be `false` if all items are actually selected
      * (every FacetFilterItem.selected == true). In that case selectedItems will contain all selected items.
      */
-    allSelected?: boolean;
+    allSelected: boolean;
 
     /**
      * Associative array containing the keys of selected FacetFilterItems. Unlike the selectedItems parameter,
@@ -26148,7 +26148,7 @@ declare module "sap/m/FacetFilterList" {
      * each object property is the FacetFilterItem key value and the value of the property is the FacetFilterItem
      * text.
      */
-    selectedKeys?: object;
+    selectedKeys: object;
   }
 
   /**
@@ -26179,7 +26179,7 @@ declare module "sap/m/FacetFilterList" {
     /**
      * Value received as user input in the `sap.m.SearchField`, and taken as a JavaScript string object.
      */
-    term?: string;
+    term: string;
   }
 
   /**
@@ -27383,7 +27383,7 @@ declare module "sap/m/FeedInput" {
     /**
      * The value of the feed input before reseting it.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -28480,13 +28480,13 @@ declare module "sap/m/FeedListItem" {
     /**
      * Dom reference of the feed item's icon to be used for positioning.
      */
-    domRef?: string;
+    domRef: string;
 
     /**
      * Function to retrieve the DOM reference for the `iconPress` event. The function returns the DOM element
      * of the icon or null
      */
-    getDomRef?: Function;
+    getDomRef: Function;
   }
 
   /**
@@ -28504,13 +28504,13 @@ declare module "sap/m/FeedListItem" {
     /**
      * Dom reference of the feed item's sender string to be used for positioning.
      */
-    domRef?: string;
+    domRef: string;
 
     /**
      * Function to retrieve the DOM reference for the `senderPress` event. The function returns the DOM element
      * of the sender link or null
      */
-    getDomRef?: Function;
+    getDomRef: Function;
   }
 
   /**
@@ -32657,20 +32657,20 @@ declare module "sap/m/GenericTile" {
     /**
      * The current scope the GenericTile was in when the event occurred.
      */
-    scope?: GenericTileScope | keyof typeof GenericTileScope;
+    scope: GenericTileScope | keyof typeof GenericTileScope;
 
     /**
      * The action that was pressed on the tile. In the Actions scope, the available actions are Press and Remove.
      * In Display scope, the parameter value is only Press.
      */
-    action?: string;
+    action: string;
 
     /**
      * The pressed DOM Element pointing to the GenericTile's DOM Element in Display scope. In Actions scope
      * it points to the more icon, when the tile is pressed, or to the DOM Element of the remove button, when
      * the remove button is pressed.
      */
-    domRef?: any;
+    domRef: any;
   }
 
   /**
@@ -35109,12 +35109,12 @@ declare module "sap/m/IconTabBar" {
     /**
      * If the tab will expand, this is true.
      */
-    expand?: boolean;
+    expand: boolean;
 
     /**
      * If the tab will collapse, this is true.
      */
-    collapse?: boolean;
+    collapse: boolean;
   }
 
   /**
@@ -35132,27 +35132,27 @@ declare module "sap/m/IconTabBar" {
     /**
      * The selected item
      */
-    item?: IconTabFilter;
+    item: IconTabFilter;
 
     /**
      * The key of the selected item
      */
-    key?: string;
+    key: string;
 
     /**
      * The key of the previous selected item
      */
-    previousKey?: string;
+    previousKey: string;
 
     /**
      * The selected item
      */
-    selectedItem?: IconTabFilter;
+    selectedItem: IconTabFilter;
 
     /**
      * The key of the selected item
      */
-    selectedKey?: string;
+    selectedKey: string;
   }
 
   /**
@@ -36539,17 +36539,17 @@ declare module "sap/m/IconTabHeader" {
     /**
      * The selected item
      */
-    item?: IconTabFilter;
+    item: IconTabFilter;
 
     /**
      * The key of the selected item
      */
-    key?: string;
+    key: string;
 
     /**
      * The key of the previous selected item
      */
-    previousKey?: string;
+    previousKey: string;
   }
 
   /**
@@ -42037,19 +42037,19 @@ declare module "sap/m/Input" {
     /**
      * The current value of the input, after a live change event.
      */
-    value?: string;
+    value: string;
 
     /**
      * Indicates that ESC key triggered the event. **Note:** This parameter will not be sent unless the ESC
      * key is pressed.
      */
-    escPressed?: boolean;
+    escPressed: boolean;
 
     /**
      * The value of the input before pressing ESC key. **Note:** This parameter will not be sent unless the
      * ESC key is pressed.
      */
-    previousValue?: string;
+    previousValue: string;
   }
 
   /**
@@ -42067,7 +42067,7 @@ declare module "sap/m/Input" {
     /**
      * The new value of the input.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -42082,14 +42082,14 @@ declare module "sap/m/Input" {
     /**
      * The current value which has been typed in the input.
      */
-    suggestValue?: string;
+    suggestValue: string;
 
     /**
      * The suggestion list is passed to this event for convenience. If you use list-based or tabular suggestions,
      * fill the suggestionList with the items you want to suggest. Otherwise, directly add the suggestions to
      * the "suggestionItems" aggregation of the input control.
      */
-    suggestionColumns?: ListBase;
+    suggestionColumns: ListBase;
   }
 
   /**
@@ -42105,7 +42105,7 @@ declare module "sap/m/Input" {
      * This is the item selected in the suggestion popup for one and two-value suggestions. For tabular suggestions,
      * this value will not be set.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
 
     /**
      * This is the row selected in the tabular suggestion popup represented as a ColumnListItem. For one and
@@ -42114,7 +42114,7 @@ declare module "sap/m/Input" {
      * **Note:** The row result function to select a result value for the string is already executed at this
      * time. To pick different value for the input field or to do follow up steps after the item has been selected.
      */
-    selectedRow?: ColumnListItem;
+    selectedRow: ColumnListItem;
   }
 
   /**
@@ -42134,7 +42134,7 @@ declare module "sap/m/Input" {
      * false. It can be used to determine whether the "value help" trigger or the "show all items" trigger has
      * been pressed.
      */
-    fromSuggestions?: boolean;
+    fromSuggestions: boolean;
   }
 
   /**
@@ -43225,7 +43225,7 @@ declare module "sap/m/InputBase" {
     /**
      * The new `value` of the `control`.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -46452,14 +46452,14 @@ declare module "sap/m/Link" {
     /**
      * Indicates whether the CTRL key was pressed when the link was selected.
      */
-    ctrlKey?: boolean;
+    ctrlKey: boolean;
 
     /**
      * Indicates whether the "meta" key was pressed when the link was selected.
      *
      * On Macintosh keyboards, this is the command key (⌘). On Windows keyboards, this is the windows key (⊞).
      */
-    metaKey?: boolean;
+    metaKey: boolean;
   }
 
   /**
@@ -46780,14 +46780,14 @@ declare module "sap/m/LinkTileContent" {
     /**
      * Indicates whether the CTRL key was pressed when the link was selected.
      */
-    ctrlKey?: boolean;
+    ctrlKey: boolean;
 
     /**
      * Indicates whether the "meta" key was pressed when the link was selected.
      *
      * On Macintosh keyboards, this is the command key (⌘). On Windows keyboards, this is the windows key (⊞).
      */
-    metaKey?: boolean;
+    metaKey: boolean;
   }
 
   /**
@@ -49531,7 +49531,7 @@ declare module "sap/m/ListBase" {
     /**
      * Item in which the context menu was opened.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
   }
 
   /**
@@ -49549,7 +49549,7 @@ declare module "sap/m/ListBase" {
     /**
      * The item which fired the delete event.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
   }
 
   /**
@@ -49569,12 +49569,12 @@ declare module "sap/m/ListBase" {
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * Total number of items.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -49596,12 +49596,12 @@ declare module "sap/m/ListBase" {
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * Total number of items.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -49621,12 +49621,12 @@ declare module "sap/m/ListBase" {
     /**
      * The item which fired the pressed event.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
 
     /**
      * The control which caused the press event within the container.
      */
-    srcControl?: Control;
+    srcControl: Control;
   }
 
   /**
@@ -49646,7 +49646,7 @@ declare module "sap/m/ListBase" {
     /**
      * The item which fired the select event.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
   }
 
   /**
@@ -49667,22 +49667,22 @@ declare module "sap/m/ListBase" {
      * The item whose selection has changed. In `MultiSelect` mode, only the up-most selected item is returned.
      * This parameter can be used for single-selection modes.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
 
     /**
      * Array of items whose selection has changed. This parameter can be used for `MultiSelect` mode.
      */
-    listItems?: ListItemBase[];
+    listItems: ListItemBase[];
 
     /**
      * Indicates whether the `listItem` parameter is selected or not.
      */
-    selected?: boolean;
+    selected: boolean;
 
     /**
      * Indicates whether the select all action is triggered or not.
      */
-    selectAll?: boolean;
+    selectAll: boolean;
   }
 
   /**
@@ -49700,24 +49700,24 @@ declare module "sap/m/ListBase" {
     /**
      * The item which fired the swipe.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
 
     /**
      * Aggregated `swipeContent` control that is shown on the right hand side of the item.
      */
-    swipeContent?: Control;
+    swipeContent: Control;
 
     /**
      * Holds which control caused the swipe event within the item.
      */
-    srcControl?: Control;
+    srcControl: Control;
 
     /**
      * Shows in which direction the user swipes and can have the value `BeginToEnd` (left to right in LTR languages
      * and right to left in RTL languages) or `EndToBegin` (right to left in LTR languages and left to right
      * in RTL languages)
      */
-    swipeDirection?: SwipeDirection | keyof typeof SwipeDirection;
+    swipeDirection: SwipeDirection | keyof typeof SwipeDirection;
   }
 
   /**
@@ -49735,17 +49735,17 @@ declare module "sap/m/ListBase" {
     /**
      * The reason of the update, e.g. Binding, Filter, Sort, Growing, Change, Refresh, Context.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * The total count of bound items. This can be used if the `growing` property is set to `true`.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -49763,17 +49763,17 @@ declare module "sap/m/ListBase" {
     /**
      * The reason of the update, e.g. Binding, Filter, Sort, Growing, Change, Refresh, Context.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * The total count of bound items. This can be used if the `growing` property is set to `true`.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -51110,12 +51110,12 @@ declare module "sap/m/MaskInput" {
     /**
      * The current value of the input, after a live change event.
      */
-    value?: string;
+    value: string;
 
     /**
      * The previous value of the input, before the last user interaction.
      */
-    previousValue?: string;
+    previousValue: string;
   }
 
   /**
@@ -51744,7 +51744,7 @@ declare module "sap/m/Menu" {
     /**
      * The `MenuItem` which was selected.
      */
-    item?: MenuItem;
+    item: MenuItem;
   }
 
   /**
@@ -53184,17 +53184,17 @@ declare module "sap/m/MenuItem" {
     /**
      * The aggregation name of the changed aggregation.
      */
-    aggregationName?: string;
+    aggregationName: string;
 
     /**
      * Which method changed the aggregation.
      */
-    methodName?: string;
+    methodName: string;
 
     /**
      * What parameters were used to change the aggregation.
      */
-    methodParams?: object;
+    methodParams: object;
   }
 
   /**
@@ -53225,12 +53225,12 @@ declare module "sap/m/MenuItem" {
     /**
      * The property name to be changed.
      */
-    propertyKey?: string;
+    propertyKey: string;
 
     /**
      * The new property value.
      */
-    propertyValue?: any;
+    propertyValue: any;
   }
 
   /**
@@ -56720,7 +56720,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the message item that contains the activeTitle.
      */
-    item?: MessageItem;
+    item: MessageItem;
   }
 
   /**
@@ -56738,7 +56738,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the control that opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -56756,7 +56756,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the control that opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -56774,7 +56774,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the control that opens the popover. See {@link sap.ui.core.MessageType} enum values for types.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -56792,7 +56792,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the control that opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -56810,12 +56810,12 @@ declare module "sap/m/MessagePopover" {
     /**
      * Refers to the `MessagePopover` item that is being presented.
      */
-    item?: MessageItem;
+    item: MessageItem;
 
     /**
      * Refers to the type of messages being shown.
      */
-    messageTypeFilter?: MessageType;
+    messageTypeFilter: MessageType;
   }
 
   /**
@@ -56833,7 +56833,7 @@ declare module "sap/m/MessagePopover" {
     /**
      * This parameter refers to the type of messages being shown.
      */
-    messageTypeFilter?: MessageType;
+    messageTypeFilter: MessageType;
   }
 
   /**
@@ -58484,7 +58484,7 @@ declare module "sap/m/MessageView" {
     /**
      * Refers to the message item that contains the activeTitle.
      */
-    item?: MessageItem;
+    item: MessageItem;
   }
 
   /**
@@ -58504,7 +58504,7 @@ declare module "sap/m/MessageView" {
     /**
      * This refers to the control which opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -58524,12 +58524,12 @@ declare module "sap/m/MessageView" {
     /**
      * Refers to the message item that is being presented.
      */
-    item?: MessageItem;
+    item: MessageItem;
 
     /**
      * Refers to the type of messages being shown. See sap.ui.core.MessageType values for types.
      */
-    messageTypeFilter?: MessageType;
+    messageTypeFilter: MessageType;
   }
 
   /**
@@ -58547,7 +58547,7 @@ declare module "sap/m/MessageView" {
     /**
      * This parameter refers to the type of messages being shown.
      */
-    messageTypeFilter?: MessageType;
+    messageTypeFilter: MessageType;
   }
 
   /**
@@ -59143,22 +59143,22 @@ declare module "sap/m/MultiComboBox" {
     /**
      * Item which selection is changed
      */
-    changedItem?: Item;
+    changedItem: Item;
 
     /**
      * Array of items whose selection has changed.
      */
-    changedItems?: Item[];
+    changedItems: Item[];
 
     /**
      * Selection state: true if item is selected, false if item is not selected
      */
-    selected?: boolean;
+    selected: boolean;
 
     /**
      * Indicates whether the select all action is triggered or not.
      */
-    selectAll?: boolean;
+    selectAll: boolean;
   }
 
   /**
@@ -59176,7 +59176,7 @@ declare module "sap/m/MultiComboBox" {
     /**
      * The selected items which are selected after list box has been closed.
      */
-    selectedItems?: Item[];
+    selectedItems: Item[];
   }
 
   /**
@@ -59940,27 +59940,27 @@ declare module "sap/m/MultiInput" {
      * sap.m.Tokenizer.TokenChangeType.RemovedAll for "removedAll" and sap.m.Tokenizer.TokenChangeType.TokensChanged
      * for "tokensChanged".
      */
-    type?: string;
+    type: string;
 
     /**
      * The added token or removed token. This parameter is used when tokenChange type is "added" or "removed".
      */
-    token?: Token;
+    token: Token;
 
     /**
      * The array of removed tokens. This parameter is used when tokenChange type is "removedAll".
      */
-    tokens?: Token[];
+    tokens: Token[];
 
     /**
      * The array of tokens that are added. This parameter is used when tokenChange type is "tokenChanged".
      */
-    addedTokens?: Token[];
+    addedTokens: Token[];
 
     /**
      * The array of tokens that are removed. This parameter is used when tokenChange type is "tokenChanged".
      */
-    removedTokens?: Token[];
+    removedTokens: Token[];
   }
 
   /**
@@ -59981,17 +59981,17 @@ declare module "sap/m/MultiInput" {
      * Type of tokenChange event. There are two TokenUpdate types: "added", "removed" Use sap.m.Tokenizer.TokenUpdateType.Added
      * for "added" and sap.m.Tokenizer.TokenUpdateType.Removed for "removed".
      */
-    type?: string;
+    type: string;
 
     /**
      * The array of tokens that are added. This parameter is used when tokenUpdate type is "added".
      */
-    addedTokens?: Token[];
+    addedTokens: Token[];
 
     /**
      * The array of tokens that are removed. This parameter is used when tokenUpdate type is "removed".
      */
-    removedTokens?: Token[];
+    removedTokens: Token[];
   }
 
   /**
@@ -61111,53 +61111,53 @@ declare module "sap/m/NavContainer" {
     /**
      * The page which had been shown before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page which had been shown before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page which is now shown after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page which is now shown after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page which has been navigated to)
      * had not been shown/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Whether was a forward navigation, triggered by "to()".
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Whether this was a back navigation, triggered by "back()".
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Whether this was a navigation to the root page, triggered by "backToTop()".
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Whether this was a navigation to a specific page, triggered by "backToPage()".
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * How the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -61175,53 +61175,53 @@ declare module "sap/m/NavContainer" {
     /**
      * The page which was shown before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page which was shown before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page which will be shown after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page which will be shown after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page which is currently navigated
      * to) has not been shown/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Whether this is a forward navigation, triggered by "to()".
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Whether this is a back navigation, triggered by "back()".
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Whether this is a navigation to the root page, triggered by "backToTop()".
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Whether this was a navigation to a specific page, triggered by "backToPage()".
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * How the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -61239,53 +61239,53 @@ declare module "sap/m/NavContainer" {
     /**
      * The page which had been shown before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page which had been shown before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page which is now shown after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page which is now shown after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page which has been navigated to)
      * had not been shown/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Whether was a forward navigation, triggered by "to()".
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Whether this was a back navigation, triggered by "back()".
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Whether this was a navigation to the root page, triggered by "backToTop()".
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Whether this was a navigation to a specific page, triggered by "backToPage()".
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * How the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -62780,7 +62780,7 @@ declare module "sap/m/NotificationListGroup" {
     /**
      * Indicates exact collapse direction
      */
-    collapsed?: boolean;
+    collapsed: boolean;
   }
 
   /**
@@ -64272,7 +64272,7 @@ declare module "sap/m/ObjectAttribute" {
     /**
      * DOM reference of the ObjectAttribute's text to be used for positioning.
      */
-    domRef?: string;
+    domRef: string;
   }
 
   /**
@@ -66521,7 +66521,7 @@ declare module "sap/m/ObjectHeader" {
     /**
      * Dom reference of the object header' icon to be used for positioning.
      */
-    domRef?: object;
+    domRef: object;
   }
 
   /**
@@ -66539,7 +66539,7 @@ declare module "sap/m/ObjectHeader" {
     /**
      * Dom reference of the object header' intro to be used for positioning.
      */
-    domRef?: object;
+    domRef: object;
   }
 
   /**
@@ -66557,7 +66557,7 @@ declare module "sap/m/ObjectHeader" {
     /**
      * Dom reference of the object header' title to be used for positioning.
      */
-    domRef?: object;
+    domRef: object;
   }
 
   /**
@@ -66575,7 +66575,7 @@ declare module "sap/m/ObjectHeader" {
     /**
      * Dom reference of the object header' titleArrow to be used for positioning.
      */
-    domRef?: object;
+    domRef: object;
   }
 
   /**
@@ -67131,7 +67131,7 @@ declare module "sap/m/ObjectIdentifier" {
     /**
      * DOM reference of the object identifier's title.
      */
-    domRef?: object;
+    domRef: object;
   }
 
   /**
@@ -68385,7 +68385,7 @@ declare module "sap/m/ObjectMarker" {
     /**
      * Type of the `ObjectMarker`.
      */
-    type?: ObjectMarkerType | keyof typeof ObjectMarkerType;
+    type: ObjectMarkerType | keyof typeof ObjectMarkerType;
   }
 
   /**
@@ -70785,12 +70785,12 @@ declare module "sap/m/p13n/BasePanel" {
     /**
      * The reason why the panel state has changed, for example, items have been added, removed, or moved.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * An object containing information about the specific item that has been changed.
      */
-    item?: Item;
+    item: Item;
   }
 
   /**
@@ -71886,7 +71886,7 @@ declare module "sap/m/p13n/Popup" {
     /**
      * The corresponding reason for closing the dialog (Ok & Cancel).
      */
-    reason?: string;
+    reason: string;
   }
 
   /**
@@ -73441,7 +73441,7 @@ declare module "sap/m/P13nColumnsPanel" {
     /**
      * `columnsItem` that needs to be added in the model.
      */
-    newItem?: P13nColumnsItem;
+    newItem: P13nColumnsItem;
   }
 
   /**
@@ -73462,19 +73462,19 @@ declare module "sap/m/P13nColumnsPanel" {
      * Contains `columnsItems` that needs to be created in the model. Deprecated as of version 1.50, replaced
      * by new parameter `items`.
      */
-    newItems?: P13nColumnsItem[];
+    newItems: P13nColumnsItem[];
 
     /**
      * Contains `columnsItems` that needs to be changed in the model. Deprecated as of version 1.50, replaced
      * by new parameter `items`.
      */
-    existingItems?: P13nColumnsItem[];
+    existingItems: P13nColumnsItem[];
 
     /**
      * Array contains an object for each item in `items` aggregation enriched with index and visibility information.
      * The item order reflects the current order of columns in the panel.
      */
-    items?: object[];
+    items: object[];
   }
 
   /**
@@ -76718,23 +76718,23 @@ declare module "sap/m/P13nFilterPanel" {
     /**
      * reason for the changeFilterItem event. Value can be added, updated or removed.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * key of the changed filterItem
      */
-    key?: string;
+    key: string;
 
     /**
      * index of the changed filterItem
      */
-    index?: int;
+    index: int;
 
     /**
      * JSON object of the changed filterItem instance (in case of reason=="removed" the itemData parameter does
      * not exist)
      */
-    itemData?: object;
+    itemData: object;
   }
 
   /**
@@ -81745,12 +81745,12 @@ declare module "sap/m/PagingButton" {
     /**
      * The number of the new position.
      */
-    newPosition?: int;
+    newPosition: int;
 
     /**
      * The number of the old position.
      */
-    oldPosition?: int;
+    oldPosition: int;
   }
 
   /**
@@ -82504,12 +82504,12 @@ declare module "sap/m/Panel" {
     /**
      * If the panel will expand, this is true. If the panel will collapse, this is false.
      */
-    expand?: boolean;
+    expand: boolean;
 
     /**
      * Identifies whether the event is triggered by an user interaction or by calling setExpanded.
      */
-    triggeredByInteraction?: boolean;
+    triggeredByInteraction: boolean;
   }
 
   /**
@@ -83419,7 +83419,7 @@ declare module "sap/m/PDFViewer" {
     /**
      * The iframe element.
      */
-    target?: any;
+    target: any;
   }
 
   /**
@@ -85851,23 +85851,23 @@ declare module "sap/m/PlanningCalendar" {
     /**
      * The selected appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * The selected appointments in case a group appointment is selected.
      */
-    appointments?: CalendarAppointment[];
+    appointments: CalendarAppointment[];
 
     /**
      * If set, the appointment was selected using multiple selection (e.g. Shift + single mouse click), meaning
      * more than the current appointment could be selected.
      */
-    multiSelect?: boolean;
+    multiSelect: boolean;
 
     /**
      * Gives the ID of the DOM element of the clicked appointment
      */
-    domRefId?: string;
+    domRefId: string;
   }
 
   /**
@@ -85885,22 +85885,22 @@ declare module "sap/m/PlanningCalendar" {
     /**
      * Start date of the selected interval, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * Interval end date as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * If set, the selected interval is a subinterval.
      */
-    subInterval?: boolean;
+    subInterval: boolean;
 
     /**
      * Row of the selected interval.
      */
-    row?: PlanningCalendarRow;
+    row: PlanningCalendarRow;
   }
 
   /**
@@ -85923,12 +85923,12 @@ declare module "sap/m/PlanningCalendar" {
      * **Note:** Intended to be used as an easy way to get an ID of a `PlanningCalendarRowHeader`. Do NOT use
      * for modification.
      */
-    headerId?: string;
+    headerId: string;
 
     /**
      * The row user clicked on.
      */
-    row?: PlanningCalendarRow;
+    row: PlanningCalendarRow;
   }
 
   /**
@@ -85951,12 +85951,12 @@ declare module "sap/m/PlanningCalendar" {
      * **Note:** Intended to be used as an easy way to get an ID of a `PlanningCalendarRowHeader`. Do NOT use
      * for modification.
      */
-    headerId?: string;
+    headerId: string;
 
     /**
      * The row user pressed.
      */
-    row?: PlanningCalendarRow;
+    row: PlanningCalendarRow;
   }
 
   /**
@@ -85974,7 +85974,7 @@ declare module "sap/m/PlanningCalendar" {
     /**
      * Array of rows whose selection has changed.
      */
-    rows?: PlanningCalendarRow[];
+    rows: PlanningCalendarRow[];
   }
 
   /**
@@ -87747,17 +87747,17 @@ declare module "sap/m/PlanningCalendarRow" {
     /**
      * Start date of the created appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * End date of the created appointment, as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * The row of the appointment.
      */
-    calendarRow?: PlanningCalendarRow;
+    calendarRow: PlanningCalendarRow;
   }
 
   /**
@@ -87775,22 +87775,22 @@ declare module "sap/m/PlanningCalendarRow" {
     /**
      * The dropped appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * Start date of the dropped appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * Dropped appointment end date as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * The row of the appointment.
      */
-    calendarRow?: PlanningCalendarRow;
+    calendarRow: PlanningCalendarRow;
   }
 
   /**
@@ -87808,27 +87808,27 @@ declare module "sap/m/PlanningCalendarRow" {
     /**
      * The dropped appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * Start date of the dropped appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * Dropped appointment end date as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * The row of the appointment.
      */
-    calendarRow?: PlanningCalendarRow;
+    calendarRow: PlanningCalendarRow;
 
     /**
      * The drop type. If true - it's "Copy", if false - it's "Move".
      */
-    copy?: boolean;
+    copy: boolean;
   }
 
   /**
@@ -87846,17 +87846,17 @@ declare module "sap/m/PlanningCalendarRow" {
     /**
      * The resized appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * Start date of the resized appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * End date of the resized appointment, as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
   }
 
   /**
@@ -88779,12 +88779,12 @@ declare module "sap/m/plugins/ColumnResizer" {
     /**
      * The column being resized.
      */
-    column?: UI5Element;
+    column: UI5Element;
 
     /**
      * The new width of the column.
      */
-    width?: CSSSize;
+    width: CSSSize;
   }
 
   /**
@@ -89330,7 +89330,7 @@ declare module "sap/m/plugins/CopyProvider" {
      * Two-dimensional mutable array of selection data to be copied to the clipboard. The first dimension represents
      * the selected rows, and the second dimension represents the cells of the selected rows.
      */
-    data?: any[][];
+    data: any[][];
   }
 
   /**
@@ -89924,7 +89924,7 @@ declare module "sap/m/plugins/DataStateIndicator" {
     /**
      * The filter object representing the entries with messages.
      */
-    filter?: Filter;
+    filter: Filter;
   }
 
   /**
@@ -89968,13 +89968,13 @@ declare module "sap/m/plugins/DataStateIndicator" {
     /**
      * The data state object.
      */
-    dataState?: DataState;
+    dataState: DataState;
 
     /**
      * The messages ({@link sap.ui.core.message.Message}) from the current `dataState` object filtered by the
      * given `filter` function.
      */
-    filteredMessages?: object[];
+    filteredMessages: object[];
   }
 
   /**
@@ -90200,12 +90200,12 @@ declare module "sap/m/plugins/PasteProvider" {
      * Two-dimentional array of strings with data from the clipboard. The first dimension represents the rows,
      * and the second dimension represents the cells of the tabular data.
      */
-    data?: string[][];
+    data: string[][];
 
     /**
      * The text data, with all special characters, from the clipboard.
      */
-    text?: string;
+    text: string;
   }
 
   /**
@@ -91874,7 +91874,7 @@ declare module "sap/m/Popover" {
     /**
      * This refers to the control which opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -91892,7 +91892,7 @@ declare module "sap/m/Popover" {
     /**
      * This refers to the control which opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -91910,7 +91910,7 @@ declare module "sap/m/Popover" {
     /**
      * This refers to the control which opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -91928,7 +91928,7 @@ declare module "sap/m/Popover" {
     /**
      * This refers to the control which opens the popover.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -93386,13 +93386,13 @@ declare module "sap/m/QuickView" {
     /**
      * This parameter refers to the control, which opens the QuickView.
      */
-    openBy?: Control;
+    openBy: Control;
 
     /**
      * This parameter contains the control, which triggers the close of the QuickView. It is undefined when
      * running on desktop or tablet.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -93410,7 +93410,7 @@ declare module "sap/m/QuickView" {
     /**
      * This parameter refers to the control, which opens the QuickView.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -93428,13 +93428,13 @@ declare module "sap/m/QuickView" {
     /**
      * This parameter refers to the control, which opens the QuickView.
      */
-    openBy?: Control;
+    openBy: Control;
 
     /**
      * This parameter contains the control, which triggers the close of the QuickView. It is undefined when
      * running on desktop or tablet.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -93452,7 +93452,7 @@ declare module "sap/m/QuickView" {
     /**
      * This parameter refers to the control, which opens the QuickView.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -93846,63 +93846,63 @@ declare module "sap/m/QuickViewBase" {
     /**
      * Determines the page, which has been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * Determines the ID of the page, which has been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * Determines the page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * Determines the ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (a control with the ID of the page, which has been navigated to) has
      * not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this was a forward navigation.
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation.
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page.
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page.
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
 
     /**
      * Determines whether this is a navigation to the top page.
      */
-    isTopPage?: boolean;
+    isTopPage: boolean;
 
     /**
      * Determines which link initiated the navigation.
      */
-    navOrigin?: Control;
+    navOrigin: Control;
   }
 
   /**
@@ -93920,58 +93920,58 @@ declare module "sap/m/QuickViewBase" {
     /**
      * The page which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (a control with the ID of the page which is currently navigated to)
      * has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation.
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation.
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page.
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page.
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
 
     /**
      * Determines which link initiated the navigation.
      */
-    navOrigin?: Control;
+    navOrigin: Control;
   }
 
   /**
@@ -96055,7 +96055,7 @@ declare module "sap/m/RadioButton" {
     /**
      * Checks whether the RadioButton is active or not.
      */
-    selected?: boolean;
+    selected: boolean;
   }
 
   /**
@@ -96738,7 +96738,7 @@ declare module "sap/m/RadioButtonGroup" {
     /**
      * Index of the selected RadioButton.
      */
-    selectedIndex?: int;
+    selectedIndex: int;
   }
 
   /**
@@ -97743,7 +97743,7 @@ declare module "sap/m/RatingIndicator" {
     /**
      * The rated value
      */
-    value?: int;
+    value: int;
   }
 
   /**
@@ -97761,7 +97761,7 @@ declare module "sap/m/RatingIndicator" {
     /**
      * The current value of the rating after a live change event.
      */
-    value?: float;
+    value: float;
   }
 
   /**
@@ -99086,13 +99086,13 @@ declare module "sap/m/ResponsivePopover" {
      * This parameter contains the control which is passed as the parameter when calling openBy method. When
      * runs on the phone, this parameter is undefined.
      */
-    openBy?: Control;
+    openBy: Control;
 
     /**
      * This parameter contains the control which triggers the close of the ResponsivePopover. This parameter
      * is undefined when runs on desktop or tablet.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -99111,7 +99111,7 @@ declare module "sap/m/ResponsivePopover" {
      * This parameter contains the control which is passed as the parameter when calling openBy method. When
      * runs on the phone, this parameter is undefined.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -99130,13 +99130,13 @@ declare module "sap/m/ResponsivePopover" {
      * This parameter contains the control which is passed as the parameter when calling openBy method. When
      * runs on the phone, this parameter is undefined.
      */
-    openBy?: Control;
+    openBy: Control;
 
     /**
      * This parameter contains the control which triggers the close of the ResponsivePopover. This parameter
      * is undefined when runs on desktop or tablet.
      */
-    origin?: Button;
+    origin: Button;
   }
 
   /**
@@ -99155,7 +99155,7 @@ declare module "sap/m/ResponsivePopover" {
      * This parameter contains the control which is passed as the parameter when calling openBy method. When
      * runs on the phone, this parameter is undefined.
      */
-    openBy?: Control;
+    openBy: Control;
   }
 
   /**
@@ -101802,7 +101802,7 @@ declare module "sap/m/SearchField" {
     /**
      * The new value of the control.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -101820,7 +101820,7 @@ declare module "sap/m/SearchField" {
     /**
      * Current search string.
      */
-    newValue?: string;
+    newValue: string;
   }
 
   /**
@@ -101838,33 +101838,33 @@ declare module "sap/m/SearchField" {
     /**
      * The search query string.
      */
-    query?: string;
+    query: string;
 
     /**
      * Suggestion list item in case if the user has selected an item from the suggestions list.
      */
-    suggestionItem?: SuggestionItem;
+    suggestionItem: SuggestionItem;
 
     /**
      * Indicates if the user pressed the refresh icon.
      */
-    refreshButtonPressed?: boolean;
+    refreshButtonPressed: boolean;
 
     /**
      * Indicates if the user pressed the clear icon.
      */
-    clearButtonPressed?: boolean;
+    clearButtonPressed: boolean;
 
     /**
      * Indicates if the user pressed the search button.
      */
-    searchButtonPressed?: boolean;
+    searchButtonPressed: boolean;
 
     /**
      * Indicates that ESC key triggered the event. **Note:** This parameter will not be sent unless the ESC
      * key is pressed.
      */
-    escPressed?: boolean;
+    escPressed: boolean;
   }
 
   /**
@@ -101882,7 +101882,7 @@ declare module "sap/m/SearchField" {
     /**
      * Current search string of the search field.
      */
-    suggestValue?: string;
+    suggestValue: string;
   }
 
   /**
@@ -102727,18 +102727,18 @@ declare module "sap/m/SegmentedButton" {
     /**
      * Reference to the button, that has been selected.
      */
-    button?: Button;
+    button: Button;
 
     /**
      * ID of the button, which has been selected.
      */
-    id?: string;
+    id: string;
 
     /**
      * Key of the button, which has been selected. This property is only filled when the control is initiated
      * with the items aggregation.
      */
-    key?: string;
+    key: string;
   }
 
   /**
@@ -102758,7 +102758,7 @@ declare module "sap/m/SegmentedButton" {
     /**
      * Reference to the item, that has been selected.
      */
-    item?: SegmentedButtonItem;
+    item: SegmentedButtonItem;
   }
 
   /**
@@ -104564,12 +104564,12 @@ declare module "sap/m/Select" {
     /**
      * The selected item.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
 
     /**
      * The previous selected item.
      */
-    previousSelectedItem?: Item;
+    previousSelectedItem: Item;
   }
 
   /**
@@ -104584,7 +104584,7 @@ declare module "sap/m/Select" {
     /**
      * The selected item.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
   }
 
   /**
@@ -105791,13 +105791,13 @@ declare module "sap/m/SelectDialog" {
      * Returns the selected list item. When no item is selected, "null" is returned. When multi-selection is
      * enabled and multiple items are selected, only the first selected item is returned.
      */
-    selectedItem?: StandardListItem;
+    selectedItem: StandardListItem;
 
     /**
      * Returns an array containing the visible selected list items. If no items are selected, an empty array
      * is returned.
      */
-    selectedItems?: StandardListItem[];
+    selectedItems: StandardListItem[];
 
     /**
      * Returns the binding contexts of the selected items including the non-visible items, but excluding the
@@ -105808,7 +105808,7 @@ declare module "sap/m/SelectDialog" {
      * are not visible upon opening the dialog, these contexts are not loaded. Therefore, these items will not
      * be included in the selectedContexts array unless they are displayed at least once.
      */
-    selectedContexts?: object[];
+    selectedContexts: object[];
   }
 
   /**
@@ -105826,13 +105826,13 @@ declare module "sap/m/SelectDialog" {
     /**
      * The value to search for, which can change at any keypress
      */
-    value?: string;
+    value: string;
 
     /**
      * The Items binding of the Select Dialog. It will only be available if the items aggregation is bound to
      * a model.
      */
-    itemsBinding?: any;
+    itemsBinding: any;
   }
 
   /**
@@ -105850,18 +105850,18 @@ declare module "sap/m/SelectDialog" {
     /**
      * The value entered in the search
      */
-    value?: string;
+    value: string;
 
     /**
      * The Items binding of the Select Dialog for search purposes. It will only be available if the items aggregation
      * is bound to a model.
      */
-    itemsBinding?: any;
+    itemsBinding: any;
 
     /**
      * Returns if the Clear button is pressed.
      */
-    clearButtonPressed?: boolean;
+    clearButtonPressed: boolean;
   }
 
   /**
@@ -106301,22 +106301,22 @@ declare module "sap/m/SelectDialogBase" {
      * The item whose selection has changed. In `MultiSelect` mode, only the up-most selected item is returned.
      * This parameter can be used for single-selection modes.
      */
-    listItem?: ListItemBase;
+    listItem: ListItemBase;
 
     /**
      * Array of items whose selection has changed. This parameter can be used for `MultiSelect` mode.
      */
-    listItems?: ListItemBase[];
+    listItems: ListItemBase[];
 
     /**
      * Indicates whether the `listItem` parameter is selected or not.
      */
-    selected?: boolean;
+    selected: boolean;
 
     /**
      * Indicates whether the select all action is triggered or not.
      */
-    selectAll?: boolean;
+    selectAll: boolean;
   }
 
   /**
@@ -106334,17 +106334,17 @@ declare module "sap/m/SelectDialogBase" {
     /**
      * The reason of the update, e.g. Binding, Filter, Sort, Growing, Change, Refresh, Context.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * The total count of bound items. This can be used if the `growing` property is set to `true`.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -106362,17 +106362,17 @@ declare module "sap/m/SelectDialogBase" {
     /**
      * The reason of the update, e.g. Binding, Filter, Sort, Growing, Change, Refresh, Context.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * Actual number of items.
      */
-    actual?: int;
+    actual: int;
 
     /**
      * The total count of bound items. This can be used if the `growing` property is set to `true`.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -108019,52 +108019,52 @@ declare module "sap/m/ViewSettingsDialog" {
     /**
      * The selected sort item.
      */
-    sortItem?: ViewSettingsItem;
+    sortItem: ViewSettingsItem;
 
     /**
      * The selected sort order (true = descending, false = ascending).
      */
-    sortDescending?: boolean;
+    sortDescending: boolean;
 
     /**
      * The selected group item.
      */
-    groupItem?: ViewSettingsItem;
+    groupItem: ViewSettingsItem;
 
     /**
      * The selected group order (true = descending, false = ascending).
      */
-    groupDescending?: boolean;
+    groupDescending: boolean;
 
     /**
      * The selected preset filter item.
      */
-    presetFilterItem?: ViewSettingsItem;
+    presetFilterItem: ViewSettingsItem;
 
     /**
      * The selected filters in an array of ViewSettingsItem.
      */
-    filterItems?: ViewSettingsItem[];
+    filterItems: ViewSettingsItem[];
 
     /**
      * The selected filter items in an object notation format: { key: boolean }. If a custom control filter
      * was displayed (for example, the user clicked on the filter item), the value for its key is set to true
      * to indicate that there has been an interaction with the control.
      */
-    filterKeys?: object;
+    filterKeys: object;
 
     /**
      * The selected filter items in an object notation format: { parentKey: { key: boolean, key2: boolean, ...
      * }, ...}. If a custom control filter was displayed (for example, the user clicked on the filter item),
      * the value for its key is set to true to indicate that there has been an interaction with the control.
      */
-    filterCompoundKeys?: object;
+    filterCompoundKeys: object;
 
     /**
      * The selected filter items in a string format to display in the control's header bar in format "Filtered
      * by: key (subkey1, subkey2, subkey3)".
      */
-    filterString?: string;
+    filterString: string;
   }
 
   /**
@@ -108082,7 +108082,7 @@ declare module "sap/m/ViewSettingsDialog" {
     /**
      * The filter item for which the details are opened.
      */
-    parentFilterItem?: ViewSettingsFilterItem;
+    parentFilterItem: ViewSettingsFilterItem;
   }
 
   /**
@@ -108946,19 +108946,19 @@ declare module "sap/m/SelectionDetails" {
     /**
      * The action that has to be processed once the action has been pressed
      */
-    action?: Item;
+    action: Item;
 
     /**
      * If the action is pressed on one of the {@link sap.m.SelectionDetailsItem items}, the parameter contains
      * a reference to the pressed {@link sap.m.SelectionDetailsItem item}. If a custom action or action group
      * of the SelectionDetails popover is pressed, this parameter refers to all {@link sap.m.SelectionDetailsItem items}
      */
-    items?: SelectionDetailsItem;
+    items: SelectionDetailsItem;
 
     /**
      * The action level of action buttons. The available levels are Item, List and Group
      */
-    level?:
+    level:
       | SelectionDetailsActionLevel
       | keyof typeof SelectionDetailsActionLevel;
   }
@@ -109017,19 +109017,19 @@ declare module "sap/m/SelectionDetails" {
      * The item on which the action has been pressed. Can be null in case a navigation was done without item
      * context, e.g. action press.
      */
-    item?: SelectionDetailsItem;
+    item: SelectionDetailsItem;
 
     /**
      * Direction of the triggered navigation, possible values are "to" and "back".
      */
-    direction?: string;
+    direction: string;
 
     /**
      * The content of the currently viewed page that was previously added via {@link sap.m.SelectionDetailsFacade#navTo}.
      * This contains the content of the page before the navigation was triggered. Can be null in case of first
      * event triggering.
      */
-    content?: Control;
+    content: Control;
   }
 
   /**
@@ -110919,7 +110919,7 @@ declare module "sap/m/SelectList" {
     /**
      * The pressed item.
      */
-    item?: Item;
+    item: Item;
   }
 
   /**
@@ -110937,7 +110937,7 @@ declare module "sap/m/SelectList" {
     /**
      * The selected item.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
   }
 
   /**
@@ -116630,7 +116630,7 @@ declare module "sap/m/semantic/SemanticSelect" {
     /**
      * The selected item.
      */
-    selectedItem?: Item;
+    selectedItem: Item;
   }
 
   /**
@@ -120126,12 +120126,12 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * Start date of the created appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * End date of the created appointment, as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
   }
 
   /**
@@ -120149,22 +120149,22 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The dropped appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * Start date of the dropped appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * Dropped appointment end date as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * The drop type. If true - it's "Copy", if false - it's "Move".
      */
-    copy?: boolean;
+    copy: boolean;
   }
 
   /**
@@ -120182,17 +120182,17 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The resized appointment.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * Start date of the resized appointment, as a UI5Date or JavaScript Date object.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * End date of the resized appointment, as a UI5Date or JavaScript Date object.
      */
-    endDate?: object;
+    endDate: object;
   }
 
   /**
@@ -120210,12 +120210,12 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The appointment on which the event was triggered.
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * All appointments with changed selected state.
      */
-    appointments?: CalendarAppointment[];
+    appointments: CalendarAppointment[];
   }
 
   /**
@@ -120233,12 +120233,12 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The start date as a UI5Date or JavaScript Date object of the focused grid cell.
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * The end date as a UI5Date or JavaScript Date object of the focused grid cell.
      */
-    endDate?: object;
+    endDate: object;
   }
 
   /**
@@ -120256,7 +120256,7 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * Date of the selected header, as a UI5Date or JavaScript Date object. It is considered as a local date.
      */
-    date?: object;
+    date: object;
   }
 
   /**
@@ -120274,7 +120274,7 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The date as a UI5Date or JavaScript Date object of the cell with the pressed more link.
      */
-    date?: object;
+    date: object;
   }
 
   /**
@@ -120292,7 +120292,7 @@ declare module "sap/m/SinglePlanningCalendar" {
     /**
      * The new start date, as a UI5Date or JavaScript Date object. It is considered as a local date.
      */
-    date?: object;
+    date: object;
   }
 
   /**
@@ -122014,7 +122014,7 @@ declare module "sap/m/Slider" {
     /**
      * The current value of the slider after a change.
      */
-    value?: float;
+    value: float;
   }
 
   /**
@@ -122029,7 +122029,7 @@ declare module "sap/m/Slider" {
     /**
      * The current value of the slider after a live change.
      */
-    value?: float;
+    value: float;
   }
 
   /**
@@ -122668,18 +122668,18 @@ declare module "sap/m/SlideTile" {
     /**
      * The current scope the SlideTile was in when the event occurred.
      */
-    scope?: GenericTileScope | keyof typeof GenericTileScope;
+    scope: GenericTileScope | keyof typeof GenericTileScope;
 
     /**
      * The action that was pressed on the tile. In the Actions scope, the available actions are Press and Remove.
      */
-    action?: string;
+    action: string;
 
     /**
      * The Element's DOM Element. In Actions scope the domRef points to the DOM Element of the remove button
      * (if pressed) or the more icon.
      */
-    domRef?: any;
+    domRef: any;
   }
 
   /**
@@ -122976,7 +122976,7 @@ declare module "sap/m/SplitApp" {
     /**
      * Returns true if the device is in landscape mode.
      */
-    landscape?: boolean;
+    landscape: boolean;
   }
 
   /**
@@ -124990,53 +124990,53 @@ declare module "sap/m/SplitContainer" {
     /**
      * The page, which had been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which had been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which has been navigated
      * to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether was a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -125067,53 +125067,53 @@ declare module "sap/m/SplitContainer" {
     /**
      * The page, which had been displayed before navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which had been displayed before navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which is now displayed after navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which is now displayed after navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Whether the "to" page (more precisely: a control with the ID of the page, which has been navigated to)
      * has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether was a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this was a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this was a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -125170,53 +125170,53 @@ declare module "sap/m/SplitContainer" {
     /**
      * The page, which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which is currently
      * navigated to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -125247,53 +125247,53 @@ declare module "sap/m/SplitContainer" {
     /**
      * The page, which was displayed before the current navigation.
      */
-    from?: Control;
+    from: Control;
 
     /**
      * The ID of the page, which was displayed before the current navigation.
      */
-    fromId?: string;
+    fromId: string;
 
     /**
      * The page, which will be displayed after the current navigation.
      */
-    to?: Control;
+    to: Control;
 
     /**
      * The ID of the page, which will be displayed after the current navigation.
      */
-    toId?: string;
+    toId: string;
 
     /**
      * Determines whether the "to" page (more precisely: a control with the ID of the page, which is currently
      * being navigated to) has not been displayed/navigated to before.
      */
-    firstTime?: boolean;
+    firstTime: boolean;
 
     /**
      * Determines whether this is a forward navigation, triggered by to().
      */
-    isTo?: boolean;
+    isTo: boolean;
 
     /**
      * Determines whether this is a back navigation, triggered by back().
      */
-    isBack?: boolean;
+    isBack: boolean;
 
     /**
      * Determines whether this is a navigation to the root page, triggered by backToTop().
      */
-    isBackToTop?: boolean;
+    isBackToTop: boolean;
 
     /**
      * Determines whether this was a navigation to a specific page, triggered by backToPage().
      */
-    isBackToPage?: boolean;
+    isBackToPage: boolean;
 
     /**
      * Determines how the navigation was triggered, possible values are "to", "back", "backToPage", and "backToTop".
      */
-    direction?: string;
+    direction: string;
   }
 
   /**
@@ -127621,7 +127621,7 @@ declare module "sap/m/StepInput" {
     /**
      * The new `value` of the `control`.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -128287,7 +128287,7 @@ declare module "sap/m/Switch" {
     /**
      * The new state of the switch.
      */
-    state?: boolean;
+    state: boolean;
   }
 
   /**
@@ -128921,7 +128921,7 @@ declare module "sap/m/TabContainer" {
     /**
      * The item to be closed.
      */
-    item?: TabContainerItem;
+    item: TabContainerItem;
   }
 
   /**
@@ -128939,7 +128939,7 @@ declare module "sap/m/TabContainer" {
     /**
      * The selected item.
      */
-    item?: TabContainerItem;
+    item: TabContainerItem;
   }
 
   /**
@@ -129450,17 +129450,17 @@ declare module "sap/m/TabContainerItem" {
     /**
      * The item changed.
      */
-    itemChanged?: TabContainerItem;
+    itemChanged: TabContainerItem;
 
     /**
      * The key of the property.
      */
-    propertyKey?: string;
+    propertyKey: string;
 
     /**
      * The value of the property.
      */
-    propertyValue?: any;
+    propertyValue: any;
   }
 
   /**
@@ -130514,7 +130514,7 @@ declare module "sap/m/Table" {
      * Column in which the context menu was opened. **Note:** This parameter might be undefined for the items
      * that are not part of a column definition.
      */
-    column?: Column;
+    column: Column;
   }
 
   /**
@@ -130533,7 +130533,7 @@ declare module "sap/m/Table" {
      * 2D array of strings with data from the clipboard. The first dimension represents the rows, and the second
      * dimension represents the cells of the tabular data.
      */
-    data?: string[][];
+    data: string[][];
   }
 
   /**
@@ -130548,17 +130548,17 @@ declare module "sap/m/Table" {
     /**
      * Returns true if there are visible columns in the pop-in area
      */
-    hasPopin?: boolean;
+    hasPopin: boolean;
 
     /**
      * Returns array of all visible columns in the pop-in area.
      */
-    visibleInPopin?: Column[];
+    visibleInPopin: Column[];
 
     /**
      * Returns array of columns that are hidden in the pop-in based on their importance. See {@link sap.m.Column#getImportance}
      */
-    hiddenInPopin?: Column[];
+    hiddenInPopin: Column[];
   }
 
   /**
@@ -132157,7 +132157,7 @@ declare module "sap/m/table/columnmenu/Menu" {
      * The element for which the menu is opened. If it is an `HTMLElement`, the closest control is passed for
      * this event (if it exists).
      */
-    openBy?: UI5Element;
+    openBy: UI5Element;
   }
 
   /**
@@ -132953,12 +132953,12 @@ declare module "sap/m/table/columnmenu/QuickGroup" {
     /**
      * The key of the property to be grouped.
      */
-    key?: string;
+    key: string;
 
     /**
      * The new grouped state.
      */
-    grouped?: boolean;
+    grouped: boolean;
   }
 
   /**
@@ -133357,12 +133357,12 @@ declare module "sap/m/table/columnmenu/QuickSort" {
     /**
      * The key of the property that is sorted.
      */
-    key?: string;
+    key: string;
 
     /**
      * The new sort order.
      */
-    sortOrder?: SortOrder | keyof typeof SortOrder;
+    sortOrder: SortOrder | keyof typeof SortOrder;
   }
 
   /**
@@ -133764,12 +133764,12 @@ declare module "sap/m/table/columnmenu/QuickTotal" {
     /**
      * The key of the property.
      */
-    key?: string;
+    key: string;
 
     /**
      * The new value.
      */
-    totaled?: boolean;
+    totaled: boolean;
   }
 
   /**
@@ -136552,13 +136552,13 @@ declare module "sap/m/TableSelectDialog" {
      * Returns the selected list item. When no item is selected, "null" is returned. When multi-selection is
      * enabled and multiple items are selected, only the first selected item is returned.
      */
-    selectedItem?: StandardListItem;
+    selectedItem: StandardListItem;
 
     /**
      * Returns an array containing the visible selected list items. If no items are selected, an empty array
      * is returned.
      */
-    selectedItems?: StandardListItem[];
+    selectedItems: StandardListItem[];
 
     /**
      * Returns the binding contexts of the selected items including the non-visible items, but excluding the
@@ -136568,7 +136568,7 @@ declare module "sap/m/TableSelectDialog" {
      * visible upon opening the dialog, these contexts are not loaded. Therefore, these items will not be included
      * in the selectedContexts array unless they are displayed at least once.
      */
-    selectedContexts?: string;
+    selectedContexts: string;
   }
 
   /**
@@ -136586,12 +136586,12 @@ declare module "sap/m/TableSelectDialog" {
     /**
      * Specifies the value entered in the search field.
      */
-    value?: string;
+    value: string;
 
     /**
      * The Items binding of the Table Select Dialog. Only available if the items aggregation is bound to a model.
      */
-    itemsBinding?: any;
+    itemsBinding: any;
   }
 
   /**
@@ -136609,18 +136609,18 @@ declare module "sap/m/TableSelectDialog" {
     /**
      * Specifies the value entered in the search field.
      */
-    value?: string;
+    value: string;
 
     /**
      * Determines the Items binding of the Table Select Dialog. Only available if the items aggregation is bound
      * to a model.
      */
-    itemsBinding?: any;
+    itemsBinding: any;
 
     /**
      * Returns if the Clear button is pressed.
      */
-    clearButtonPressed?: boolean;
+    clearButtonPressed: boolean;
   }
 
   /**
@@ -137841,7 +137841,7 @@ declare module "sap/m/TextArea" {
     /**
      * The new `value` of the control.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -138703,7 +138703,7 @@ declare module "sap/m/TileContainer" {
     /**
      * The deleted Tile.
      */
-    tile?: Tile;
+    tile: Tile;
   }
 
   /**
@@ -138721,12 +138721,12 @@ declare module "sap/m/TileContainer" {
     /**
      * The Tile that has been moved.
      */
-    tile?: Tile;
+    tile: Tile;
 
     /**
      * The new index of the Tile in the tiles aggregation.
      */
-    newIndex?: int;
+    newIndex: int;
   }
 
   /**
@@ -140298,7 +140298,7 @@ declare module "sap/m/TimePicker" {
     /**
      * Indicator for a valid time
      */
-    valid?: boolean;
+    valid: boolean;
   }
 
   /**
@@ -141042,7 +141042,7 @@ declare module "sap/m/TimePickerSliders" {
     /**
      * The new `value` of the control.
      */
-    value?: string;
+    value: string;
   }
 
   /**
@@ -141857,7 +141857,7 @@ declare module "sap/m/ToggleButton" {
     /**
      * The current pressed state of the control.
      */
-    pressed?: boolean;
+    pressed: boolean;
   }
 
   /**
@@ -143462,27 +143462,27 @@ declare module "sap/m/Tokenizer" {
      * sap.m.Tokenizer.TokenChangeType.RemovedAll for "removedAll" and sap.m.Tokenizer.TokenChangeType.TokensChanged
      * for "tokensChanged".
      */
-    type?: string;
+    type: string;
 
     /**
      * the added token or removed token. This parameter is used when tokenChange type is "added" or "removed".
      */
-    token?: Token;
+    token: Token;
 
     /**
      * the array of removed tokens. This parameter is used when tokenChange type is "removedAll".
      */
-    tokens?: Token[];
+    tokens: Token[];
 
     /**
      * the array of tokens that are added. This parameter is used when tokenChange type is "tokenChanged".
      */
-    addedTokens?: Token[];
+    addedTokens: Token[];
 
     /**
      * the array of tokens that are removed. This parameter is used when tokenChange type is "tokenChanged".
      */
-    removedTokens?: Token[];
+    removedTokens: Token[];
   }
 
   /**
@@ -143502,12 +143502,12 @@ declare module "sap/m/Tokenizer" {
     /**
      * The array of tokens that are removed.
      */
-    tokens?: Token[];
+    tokens: Token[];
 
     /**
      * Keycode of the key pressed for deletion (backspace or delete).
      */
-    keyCode?: number;
+    keyCode: number;
   }
 
   /**
@@ -143528,17 +143528,17 @@ declare module "sap/m/Tokenizer" {
      * Type of tokenChange event. There are two TokenUpdate types: "added", "removed" Use sap.m.Tokenizer.TokenUpdateType.Added
      * for "added" and sap.m.Tokenizer.TokenUpdateType.Removed for "removed".
      */
-    type?: string;
+    type: string;
 
     /**
      * The array of tokens that are added. This parameter is used when tokenUpdate type is "added".
      */
-    addedTokens?: Token[];
+    addedTokens: Token[];
 
     /**
      * The array of tokens that are removed. This parameter is used when tokenUpdate type is "removed".
      */
-    removedTokens?: Token[];
+    removedTokens: Token[];
   }
 
   /**
@@ -144255,7 +144255,7 @@ declare module "sap/m/Toolbar" {
     /**
      * The toolbar item that was pressed
      */
-    srcControl?: Control;
+    srcControl: Control;
   }
 
   /**
@@ -145011,17 +145011,17 @@ declare module "sap/m/Tree" {
     /**
      * Index of the expanded/collapsed item
      */
-    itemIndex?: int;
+    itemIndex: int;
 
     /**
      * Binding context of the item
      */
-    itemContext?: object;
+    itemContext: object;
 
     /**
      * Flag that indicates whether the item has been expanded or collapsed
      */
-    expanded?: boolean;
+    expanded: boolean;
   }
 
   /**
@@ -146574,7 +146574,7 @@ declare module "sap/m/upload/Uploader" {
     /**
      * The item that is going to be deleted.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -146592,7 +146592,7 @@ declare module "sap/m/upload/Uploader" {
     /**
      * The item that was uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
 
     /**
      * A JSON object containing the additional response parameters like response, responseXML, readyState, status
@@ -146608,7 +146608,7 @@ declare module "sap/m/upload/Uploader" {
      * }
      * ```
      */
-    responseXHR?: object;
+    responseXHR: object;
   }
 
   /**
@@ -146626,19 +146626,19 @@ declare module "sap/m/upload/Uploader" {
     /**
      * The item that is being uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
 
     /**
      * The number of bytes transferred since the beginning of the operation. This doesn't include headers and
      * other overhead, but only the content itself
      */
-    loaded?: int;
+    loaded: int;
 
     /**
      * The total number of bytes of content that will be transferred during the operation. If the total size
      * is unknown, this value is zero.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -146656,7 +146656,7 @@ declare module "sap/m/upload/Uploader" {
     /**
      * The item that is going to be uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -147210,7 +147210,7 @@ declare module "sap/m/upload/UploaderTableItem" {
     /**
      * The item that was uploaded.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
 
     /**
      * A JSON object containing the additional response parameters like response, responseXML, readyState, status
@@ -147226,7 +147226,7 @@ declare module "sap/m/upload/UploaderTableItem" {
      * }
      * ```
      */
-    responseXHR?: object;
+    responseXHR: object;
   }
 
   /**
@@ -147244,19 +147244,19 @@ declare module "sap/m/upload/UploaderTableItem" {
     /**
      * The item that is being uploaded.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
 
     /**
      * The number of bytes transferred since the beginning of the operation. This doesn't include headers and
      * other overhead, but only the content itself
      */
-    loaded?: int;
+    loaded: int;
 
     /**
      * The total number of bytes of content that is transferred during the operation. If the total size is unknown,
      * this value is zero.
      */
-    total?: int;
+    total: int;
   }
 
   /**
@@ -147274,7 +147274,7 @@ declare module "sap/m/upload/UploaderTableItem" {
     /**
      * The item that is going to be uploaded.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -150351,7 +150351,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file that has just been added.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150369,7 +150369,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The item edited.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150387,7 +150387,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The item removed from the set of items to be uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150405,7 +150405,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file to be added to the set of items to be uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150423,7 +150423,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The item to be edited.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150441,7 +150441,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The item to be removed from the set of items to be uploaded.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150459,7 +150459,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file whose upload is just about to start.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150477,7 +150477,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file whose upload is about to be terminated.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150495,7 +150495,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file that fails to meet the file name length restriction specified in the `maxFileNameLength` property.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150513,7 +150513,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The renamed UI element as an UploadSetItem.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150531,13 +150531,13 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file that fails to meet the file size restriction specified in the `maxFileSize` property.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
 
     /**
      * The size of a file in MB, that fails to meet the file size restriction specified in the `maxFileSize`
      * property.
      */
-    fileSize?: float;
+    fileSize: float;
   }
 
   /**
@@ -150555,7 +150555,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file that fails to meet the file type restriction specified in the `fileType` property.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150599,7 +150599,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file that fails to meet the media type restriction specified in the `mediaTypes` property.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -150617,7 +150617,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * Items whose selection status has just been changed.
      */
-    items?: UploadSetItem[];
+    items: UploadSetItem[];
   }
 
   /**
@@ -150635,7 +150635,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file whose upload has just been completed.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
 
     /**
      * Response message which comes from the server.
@@ -150644,7 +150644,7 @@ declare module "sap/m/upload/UploadSet" {
      * of the iFrame. It can consist of a return code and an optional message. This does not work in cross-domain
      * scenarios.
      */
-    response?: string;
+    response: string;
 
     /**
      * ReadyState of the XHR request.
@@ -150652,7 +150652,7 @@ declare module "sap/m/upload/UploadSet" {
      * Required for receiving a `readyState` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    readyState?: int;
+    readyState: int;
 
     /**
      * Status of the XHR request.
@@ -150660,7 +150660,7 @@ declare module "sap/m/upload/UploadSet" {
      * Required for receiving a `status` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    status?: int;
+    status: int;
 
     /**
      * Http-Response which comes from the server.
@@ -150669,7 +150669,7 @@ declare module "sap/m/upload/UploadSet" {
      *
      * This property is not supported by Internet Explorer 9.
      */
-    responseXML?: string;
+    responseXML: string;
 
     /**
      * Http-Response-Headers which come from the server.
@@ -150680,7 +150680,7 @@ declare module "sap/m/upload/UploadSet" {
      * Required for receiving `headers` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    headers?: object;
+    headers: object;
   }
 
   /**
@@ -150698,7 +150698,7 @@ declare module "sap/m/upload/UploadSet" {
     /**
      * The file whose upload has just been terminated.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -151865,7 +151865,7 @@ declare module "sap/m/upload/UploadSetItem" {
     /**
      * The item on which the open action has been invoked.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -151883,7 +151883,7 @@ declare module "sap/m/upload/UploadSetItem" {
     /**
      * The item on which the open action has been invoked.
      */
-    item?: UploadSetItem;
+    item: UploadSetItem;
   }
 
   /**
@@ -153937,7 +153937,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * Items in ready state for upload process
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -153955,7 +153955,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file whose upload is just about to start.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -153973,7 +153973,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file that fails to meet the file name length restriction specified in the `maxFileNameLength` property.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -153991,7 +153991,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file that fails to meet the file size restriction specified in the `maxFileSize` property.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -154009,7 +154009,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file that fails to meet the file type restriction specified in the `fileType` property.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -154053,7 +154053,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The renamed UI element is of UploadSetwithTableItem type.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -154071,7 +154071,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file that fails to meet the media type restriction specified in the `mediaTypes` property.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
   }
 
   /**
@@ -154089,7 +154089,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
     /**
      * The file whose upload has just been completed.
      */
-    item?: UploadSetwithTableItem;
+    item: UploadSetwithTableItem;
 
     /**
      * Response message that comes from the server.
@@ -154098,7 +154098,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      * of the iFrame. It can consist of a return code and an optional message. This does not work in cross-domain
      * scenarios.
      */
-    response?: string;
+    response: string;
 
     /**
      * ReadyState of the XHR request.
@@ -154106,7 +154106,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      * Required for receiving a `readyState` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    readyState?: string;
+    readyState: string;
 
     /**
      * Status of the XHR request.
@@ -154114,7 +154114,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      * Required for receiving a `status` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    status?: string;
+    status: string;
 
     /**
      * Http-Response which comes from the server.
@@ -154123,7 +154123,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      *
      * This property is not supported by Internet Explorer 9.
      */
-    responseXML?: string;
+    responseXML: string;
 
     /**
      * Http-Response which comes from the server.
@@ -154132,7 +154132,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      *
      * This property is not supported by Internet Explorer 9.
      */
-    responseText?: string;
+    responseText: string;
 
     /**
      * Http-Response-Headers which come from the server.
@@ -154143,7 +154143,7 @@ declare module "sap/m/upload/UploadSetwithTable" {
      * Required for receiving `headers` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    headers?: object;
+    headers: object;
   }
 
   /**
@@ -156660,20 +156660,20 @@ declare module "sap/m/UploadCollection" {
     /**
      * Specifies the name of the file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * A function that adds a header parameter to the file that will be uploaded. The function accepts one parameter
      * of type `sap.m.UploadCollectionParameter` which specifies the header parameter that will be added.
      */
-    addHeaderParameter?: Function;
+    addHeaderParameter: Function;
 
     /**
      * A function that returns the corresponding header parameter (type `sap.m.UploadCollectionParameter`) if
      * available. The function accepts one optional parameter of type `string`, which is the name of the header
      * parameter. If no parameter is provided all header parameters are returned.
      */
-    getHeaderParameter?: Function;
+    getHeaderParameter: Function;
   }
 
   /**
@@ -156692,14 +156692,14 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `files` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * A FileList of individually selected files from the underlying system. See www.w3.org for the FileList
      * Interface definition. Restriction: Internet Explorer 9 supports only single file with property file.name.
      * Since version 1.28.0.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -156718,12 +156718,12 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `item` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * An item to be deleted from the collection. Since version 1.28.0.
      */
-    item?: UploadCollectionItem;
+    item: UploadCollectionItem;
   }
 
   /**
@@ -156742,13 +156742,13 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `files` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * A FileList of individually selected files from the underlying system. Restriction: Internet Explorer
      * 9 supports only single file with property file.name. Since version 1.28.0.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -156767,17 +156767,17 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `item` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * The new file name. This parameter is deprecated since 1.28.0. Use the `item` parameter instead.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * The renamed UI element as an UploadCollectionItem. Since 1.28.0.
      */
-    item?: UploadCollectionItem;
+    item: UploadCollectionItem;
   }
 
   /**
@@ -156796,19 +156796,19 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `files` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * The size in MB of a file to be uploaded. This parameter is deprecated since 1.28.0. Use the `files` parameter
      * instead.
      */
-    fileSize?: string;
+    fileSize: string;
 
     /**
      * A FileList of individually selected files from the underlying system. Restriction: Internet Explorer
      * 9 supports only single file with property file.name. Since 1.28.0.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -156827,17 +156827,17 @@ declare module "sap/m/UploadCollection" {
      * The item whose selection has changed. In `MultiSelect` mode, only the topmost selected item is returned.
      * This parameter can be used for single-selection modes.
      */
-    selectedItem?: UploadCollectionItem;
+    selectedItem: UploadCollectionItem;
 
     /**
      * Array of items whose selection has changed. This parameter can be used for `MultiSelect` mode.
      */
-    selectedItems?: UploadCollectionItem[];
+    selectedItems: UploadCollectionItem[];
 
     /**
      * Indicates whether the `listItem` parameter is selected or not.
      */
-    selected?: boolean;
+    selected: boolean;
   }
 
   /**
@@ -156856,23 +156856,23 @@ declare module "sap/m/UploadCollection" {
      * A unique Id of the attached document. This parameter is deprecated since 1.28.0. Use the `files` parameter
      * instead.
      */
-    documentId?: string;
+    documentId: string;
 
     /**
      * File type. This parameter is deprecated since 1.28.0. Use the `files` parameter instead.
      */
-    fileType?: string;
+    fileType: string;
 
     /**
      * MIME type. This parameter is deprecated since 1.28.0. Use the `files` parameter instead.
      */
-    mimeType?: string;
+    mimeType: string;
 
     /**
      * A FileList of individually selected files from the underlying system. Restriction: Internet Explorer
      * 9 supports only single file. Since 1.28.0.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -156890,19 +156890,19 @@ declare module "sap/m/UploadCollection" {
     /**
      * Ready state XHR. This parameter is deprecated since 1.28.0. Use the `files` parameter instead.
      */
-    readyStateXHR?: string;
+    readyStateXHR: string;
 
     /**
      * Response of the completed upload request. This parameter is deprecated since 1.28.0. Use the `files`
      * parameter instead.
      */
-    response?: string;
+    response: string;
 
     /**
      * Status Code of the completed upload event. This parameter is deprecated since 1.28.0. Use the `files`
      * parameter instead.
      */
-    status?: string;
+    status: string;
 
     /**
      * A list of uploaded files. Each entry contains the following members. fileName : The name of a file to
@@ -156916,7 +156916,7 @@ declare module "sap/m/UploadCollection" {
      * is reflected by a property in the header-object, with the property value reflecting the header-field's
      * content. This property is not supported by Internet Explorer 9 and lower. Since 1.28.0.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -156934,14 +156934,14 @@ declare module "sap/m/UploadCollection" {
     /**
      * Specifies the name of the file of which the upload is to be terminated.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * A function that returns the corresponding header parameter (type `sap.m.UploadCollectionParameter`) if
      * available. The function accepts one optional parameter of type `string`, which is the name of the header
      * parameter. If no parameter is provided all header parameters are returned.
      */
-    getHeaderParameter?: Function;
+    getHeaderParameter: Function;
   }
 
   /**
@@ -160069,35 +160069,35 @@ declare module "sap/m/VariantManagement" {
      * List of changed variants. Each entry contains a 'key' - the variant key and a 'name' - the new title
      * of the variant
      */
-    renamed?: object[];
+    renamed: object[];
 
     /**
      * List of deleted variant keys
      */
-    deleted?: string[];
+    deleted: string[];
 
     /**
      * List of variant keys and the associated Execute on Selection indicator. Each entry contains a 'key' -
      * the variant key and a 'exe' - flag describing the intention
      */
-    exe?: object[];
+    exe: object[];
 
     /**
      * List of variant keys and the associated favorite indicator. Each entry contains a 'key' - the variant
      * key and a 'visible' - flag describing the intention
      */
-    fav?: object[];
+    fav: object[];
 
     /**
      * The default variant key
      */
-    def?: string;
+    def: string;
 
     /**
      * List of variant keys and the associated contexts array. Each entry contains a 'key' - the variant key
      * and a 'contexts' - array describing the contexts
      */
-    contexts?: object[];
+    contexts: object[];
   }
 
   /**
@@ -160128,43 +160128,43 @@ declare module "sap/m/VariantManagement" {
     /**
      * Variant title
      */
-    name?: string;
+    name: string;
 
     /**
      * Indicates if an existing variant is updated or if a new variant is created. Basically 'Save' operation
      * leads to overwrite `true`, while 'Save As' leads to overwrite `false`.
      */
-    overwrite?: boolean;
+    overwrite: boolean;
 
     /**
      * Variant key. This property is only set, when `overwrite` is set to `true`.
      */
-    key?: string;
+    key: string;
 
     /**
      * Apply Automatically indicator
      */
-    execute?: boolean;
+    execute: boolean;
 
     /**
      * The default variant indicator
      */
-    def?: boolean;
+    def: boolean;
 
     /**
      * Indicates the check box state for 'Public'.
      */
-    public?: boolean;
+    public: boolean;
 
     /**
      * Array describing the contexts.
      */
-    contexts?: object[];
+    contexts: object[];
 
     /**
      * Indicates the check box state for 'Create Tile'. **Note:** This event parameter is used only internally.
      */
-    tile?: boolean;
+    tile: boolean;
   }
 
   /**
@@ -160182,7 +160182,7 @@ declare module "sap/m/VariantManagement" {
     /**
      * Variant key
      */
-    key?: string;
+    key: string;
   }
 
   /**
@@ -161294,17 +161294,17 @@ declare module "sap/m/ViewSettingsItem" {
     /**
      * Instance of the item that changed.
      */
-    changedItem?: ViewSettingsItem;
+    changedItem: ViewSettingsItem;
 
     /**
      * Key of the changed property.
      */
-    propertyKey?: string;
+    propertyKey: string;
 
     /**
      * Value of the changed property.
      */
-    propertyValue?: any;
+    propertyValue: any;
   }
 
   /**
@@ -161900,7 +161900,7 @@ declare module "sap/m/WheelSlider" {
     /**
      * The new selected key
      */
-    newKey?: string;
+    newKey: string;
   }
 
   /**
@@ -163053,7 +163053,7 @@ declare module "sap/m/Wizard" {
     /**
      * The newly selected step.
      */
-    step?: WizardStep;
+    step: WizardStep;
   }
 
   /**
@@ -163071,7 +163071,7 @@ declare module "sap/m/Wizard" {
     /**
      * The index of the activated step as a parameter. One-based.
      */
-    index?: int;
+    index: int;
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/output-dts/sap.tnt.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.tnt.d.ts
@@ -897,7 +897,7 @@ declare module "sap/tnt/NavigationList" {
     /**
      * The selected item.
      */
-    item?: Item;
+    item: Item;
   }
 
   /**
@@ -1441,7 +1441,7 @@ declare module "sap/tnt/NavigationListItem" {
     /**
      * The selected item.
      */
-    item?: Item;
+    item: Item;
   }
 
   /**
@@ -1919,7 +1919,7 @@ declare module "sap/tnt/SideNavigation" {
     /**
      * The selected item.
      */
-    item?: Item;
+    item: Item;
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
@@ -10425,27 +10425,27 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * ManagedObject instance whose property should have received the model update.
      */
-    element?: ManagedObject;
+    element: ManagedObject;
 
     /**
      * Name of the property for which the binding should have been updated.
      */
-    property?: string;
+    property: string;
 
     /**
      * Data type used in the binding (if any).
      */
-    type?: Type;
+    type: Type;
 
     /**
      * New value (model representation) as propagated from the model.
      */
-    newValue?: any;
+    newValue: any;
 
     /**
      * Old value (external representation) as previously stored in the ManagedObject.
      */
-    oldValue?: any;
+    oldValue: any;
   }
 
   /**
@@ -10476,32 +10476,32 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * ManagedObject instance whose property initiated the model update.
      */
-    element?: ManagedObject;
+    element: ManagedObject;
 
     /**
      * Name of the property for which the bound model property should have been been updated.
      */
-    property?: string;
+    property: string;
 
     /**
      * Data type used in the binding.
      */
-    type?: Type;
+    type: Type;
 
     /**
      * New value (external representation) as parsed by the binding.
      */
-    newValue?: any;
+    newValue: any;
 
     /**
      * Old value (external representation) as previously stored in the ManagedObject.
      */
-    oldValue?: any;
+    oldValue: any;
 
     /**
      * Localized message describing the parse error
      */
-    message?: string;
+    message: string;
   }
 
   /**
@@ -10519,32 +10519,32 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * ManagedObject instance whose property initiated the model update.
      */
-    element?: ManagedObject;
+    element: ManagedObject;
 
     /**
      * Name of the property for which the bound model property should have been been updated.
      */
-    property?: string;
+    property: string;
 
     /**
      * Data type used in the binding.
      */
-    type?: Type;
+    type: Type;
 
     /**
      * New value (external representation) as parsed and validated by the binding.
      */
-    newValue?: any;
+    newValue: any;
 
     /**
      * Old value (external representation) as previously stored in the ManagedObject.
      */
-    oldValue?: any;
+    oldValue: any;
 
     /**
      * Localized message describing the validation issues
      */
-    message?: string;
+    message: string;
   }
 
   /**
@@ -10562,17 +10562,17 @@ declare module "sap/ui/base/ManagedObject" {
     /**
      * ManagedObject instance whose property initiated the model update.
      */
-    element?: ManagedObject;
+    element: ManagedObject;
 
     /**
      * Name of the property for which the bound model property has been updated.
      */
-    property?: string;
+    property: string;
 
     /**
      * Data type used in the binding.
      */
-    type?: Type;
+    type: Type;
 
     /**
      * New value (external representation) as propagated to the model.
@@ -10580,12 +10580,12 @@ declare module "sap/ui/base/ManagedObject" {
      * **Note: **the model might modify (normalize) the value again and this modification will be stored in
      * the ManagedObject. The 'newValue' parameter of this event contains the value **before** such a normalization.
      */
-    newValue?: any;
+    newValue: any;
 
     /**
      * Old value (external representation) as previously stored in the ManagedObject.
      */
-    oldValue?: any;
+    oldValue: any;
   }
 
   /**
@@ -15916,7 +15916,7 @@ declare module "sap/ui/core/ComponentContainer" {
     /**
      * Reference to the created component instance
      */
-    component?: UIComponent;
+    component: UIComponent;
   }
 
   /**
@@ -15934,7 +15934,7 @@ declare module "sap/ui/core/ComponentContainer" {
     /**
      * The reason object as returned by the component promise
      */
-    reason?: object;
+    reason: object;
   }
 
   /**
@@ -18278,7 +18278,7 @@ declare module "sap/ui/core/Control" {
     /**
      * field group IDs of the logical field groups to validate
      */
-    fieldGroupIds?: string[];
+    fieldGroupIds: string[];
   }
 
   /**
@@ -21557,17 +21557,17 @@ declare module "sap/ui/core/dnd/DragDropInfo" {
     /**
      * The target element that will be dragged
      */
-    target?: UI5Element;
+    target: UI5Element;
 
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -21890,17 +21890,17 @@ declare module "sap/ui/core/dnd/DragInfo" {
     /**
      * The target element that is being dragged
      */
-    target?: UI5Element;
+    target: UI5Element;
 
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -21918,17 +21918,17 @@ declare module "sap/ui/core/dnd/DragInfo" {
     /**
      * The target element that will be dragged
      */
-    target?: UI5Element;
+    target: UI5Element;
 
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -22597,17 +22597,17 @@ declare module "sap/ui/core/dnd/DropInfo" {
     /**
      * The target element on which the dragged element will be dropped
      */
-    target?: UI5Element;
+    target: UI5Element;
 
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -22625,24 +22625,24 @@ declare module "sap/ui/core/dnd/DropInfo" {
     /**
      * The target element on which the dragged element will be dropped
      */
-    target?: UI5Element;
+    target: UI5Element;
 
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The calculated position of the drop action relative to the `target`
      */
-    dropPosition?:
+    dropPosition:
       | dnd.RelativeDropPosition
       | keyof typeof dnd.RelativeDropPosition;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -22660,29 +22660,29 @@ declare module "sap/ui/core/dnd/DropInfo" {
     /**
      * The UI5 `dragSession` object that exists only during drag and drop
      */
-    dragSession?: DragSession;
+    dragSession: DragSession;
 
     /**
      * The element being dragged
      */
-    draggedControl?: UI5Element;
+    draggedControl: UI5Element;
 
     /**
      * The element being dropped
      */
-    droppedControl?: UI5Element;
+    droppedControl: UI5Element;
 
     /**
      * The calculated position of the drop action relative to the `droppedControl`
      */
-    dropPosition?:
+    dropPosition:
       | dnd.RelativeDropPosition
       | keyof typeof dnd.RelativeDropPosition;
 
     /**
      * The underlying browser event
      */
-    browserEvent?: DragEvent;
+    browserEvent: DragEvent;
   }
 
   /**
@@ -26943,7 +26943,7 @@ declare module "sap/ui/core/HTML" {
      * Whether the current DOM of the control has been preserved (true) or not (e.g. rendered from content property
      * or it is an empty HTML control).
      */
-    isPreservedDOM?: boolean;
+    isPreservedDOM: boolean;
   }
 
   /**
@@ -27240,7 +27240,7 @@ declare module "sap/ui/core/hyphenation/Hyphenation" {
     /**
      * The message of the error.
      */
-    sErrorMessage?: string;
+    sErrorMessage: string;
   }
 
   /**
@@ -32240,12 +32240,12 @@ declare module "sap/ui/core/message/MessageProcessor" {
     /**
      * Messages already existing before the `messageChange` event was fired.
      */
-    oldMessages?: Message;
+    oldMessages: Message;
 
     /**
      * New messages added by the trigger of the `messageChange` event.
      */
-    newMessages?: Message;
+    newMessages: Message;
   }
 
   /**
@@ -35826,14 +35826,14 @@ declare module "sap/ui/core/Popup" {
     /**
      * Indicates whether a blocking layer is currently visible `visible: true` or not `visible: false`
      */
-    visible?: boolean;
+    visible: boolean;
 
     /**
      * In case a blocking layer is visible, the `zIndex` property will represent the zIndex at which the blocking
      * layer is displayed. In case of `visible: false`, `zIndex` represents the zIndex value of the last open
      * popup.
      */
-    zIndex?: number;
+    zIndex: number;
   }
 
   /**
@@ -37623,18 +37623,18 @@ declare module "sap/ui/core/routing/Route" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The nested route instance of this route. The event is fired on this route because the pattern in the
@@ -37660,18 +37660,18 @@ declare module "sap/ui/core/routing/Route" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The nested route instance of this route. The event is fired on this route because the pattern in the
@@ -37685,23 +37685,23 @@ declare module "sap/ui/core/routing/Route" {
      * The first View or ComponentContainer instance which is created out of the first target. If multiple targets
      * are displayed, use oEvent.getParameters.views to get all instances
      */
-    view?: View | ComponentContainer;
+    view: View | ComponentContainer;
 
     /**
      * All View or ComponentContainer instances which are created out of the targets.
      */
-    views?: Array<View | ComponentContainer>;
+    views: Array<View | ComponentContainer>;
 
     /**
      * The container control to which the first View or ComponentContainer is added. If multiple targets are
      * displayed, use oEvent.getParameters.targetControls to get all container controls
      */
-    targetControl?: Control;
+    targetControl: Control;
 
     /**
      * The container controls to which the View or ComponentContainer instances are added.
      */
-    targetControls?: Control[];
+    targetControls: Control[];
   }
 
   /**
@@ -37716,40 +37716,40 @@ declare module "sap/ui/core/routing/Route" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The first View or ComponentContainer instance which is created out of the first target. If multiple targets
      * are displayed, use oEvent.getParameters.views to get all instances
      */
-    view?: View | ComponentContainer;
+    view: View | ComponentContainer;
 
     /**
      * All View or ComponentContainer instances which are created out of the targets.
      */
-    views?: Array<View | ComponentContainer>;
+    views: Array<View | ComponentContainer>;
 
     /**
      * The container control to which the first View or ComponentContainer is added. If multiple targets are
      * displayed, use oEvent.getParameters.targetControls to get all container controls
      */
-    targetControl?: Control;
+    targetControl: Control;
 
     /**
      * The container controls to which the View or ComponentContainer instances are added.
      */
-    targetControls?: Control[];
+    targetControls: Control[];
   }
 
   /**
@@ -37767,18 +37767,18 @@ declare module "sap/ui/core/routing/Route" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
   }
 
   /**
@@ -38216,27 +38216,27 @@ declare module "sap/ui/core/routing/Target" {
     /**
      * The view that got displayed.
      */
-    view?: object;
+    view: object;
 
     /**
      * The control that now contains the view in the controlAggregation
      */
-    control?: object;
+    control: object;
 
     /**
      * The options object passed to the constructor {@link sap.ui.core.routing.Target#constructor}
      */
-    config?: object;
+    config: object;
 
     /**
      * The data passed into the {@link sap.ui.core.routing.Target#display} function
      */
-    data?: object;
+    data: object;
 
     /**
      * Whether the target is relevant to the matched route or not
      */
-    routeRelevant?: object;
+    routeRelevant: object;
   }
 
   /**
@@ -38449,7 +38449,7 @@ declare module "sap/ui/core/routing/HashChanger" {
     /**
      * The relevant hash segment
      */
-    hash?: string;
+    hash: string;
   }
 
   /**
@@ -38561,12 +38561,12 @@ declare module "sap/ui/core/routing/HashChangerBase" {
     /**
      * The hash segment before it's changed
      */
-    oldHash?: string;
+    oldHash: string;
 
     /**
      * The new hash segment
      */
-    newHash?: object;
+    newHash: object;
 
     /**
      * The full format of the hash if the newHash only contains part of the relevant hash
@@ -38593,7 +38593,7 @@ declare module "sap/ui/core/routing/HashChangerBase" {
     /**
      * The relevant hash segment
      */
-    hash?: string;
+    hash: string;
   }
 
   /**
@@ -39818,18 +39818,18 @@ declare module "sap/ui/core/routing/Router" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The nested route instance of this route. The event is fired on this route because the pattern in the
@@ -39855,7 +39855,7 @@ declare module "sap/ui/core/routing/Router" {
     /**
      * the current URL hash which did not match any route
      */
-    hash?: string;
+    hash: string;
   }
 
   /**
@@ -39873,18 +39873,18 @@ declare module "sap/ui/core/routing/Router" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The nested route instance of this route. The event is fired on this route because the pattern in the
@@ -39898,23 +39898,23 @@ declare module "sap/ui/core/routing/Router" {
      * The first View or ComponentContainer instance which is created out of the first target. If multiple targets
      * are displayed, use oEvent.getParameters.views to get all instances
      */
-    view?: View | ComponentContainer;
+    view: View | ComponentContainer;
 
     /**
      * All View or ComponentContainer instances which are created out of the targets.
      */
-    views?: Array<View | ComponentContainer>;
+    views: Array<View | ComponentContainer>;
 
     /**
      * The container control to which the first View or ComponentContainer is added. If multiple targets are
      * displayed, use oEvent.getParameters.targetControls to get all container controls
      */
-    targetControl?: Control;
+    targetControl: Control;
 
     /**
      * The container controls to which the View or ComponentContainer instances are added.
      */
-    targetControls?: Control[];
+    targetControls: Control[];
   }
 
   /**
@@ -39932,40 +39932,40 @@ declare module "sap/ui/core/routing/Router" {
     /**
      * The name of the route
      */
-    name?: string;
+    name: string;
 
     /**
      * A key-value pair object which contains the arguments defined in the route resolved with the corresponding
      * information from the current URL hash
      */
-    arguments?: object;
+    arguments: object;
 
     /**
      * The configuration object of the route
      */
-    config?: object;
+    config: object;
 
     /**
      * The first View or ComponentContainer instance which is created out of the first target. If multiple targets
      * are displayed, use oEvent.getParameters.views to get all instances
      */
-    view?: View | ComponentContainer;
+    view: View | ComponentContainer;
 
     /**
      * All View or ComponentContainer instances which are created out of the targets.
      */
-    views?: Array<View | ComponentContainer>;
+    views: Array<View | ComponentContainer>;
 
     /**
      * The container control to which the first View or ComponentContainer is added. If multiple targets are
      * displayed, use oEvent.getParameters.targetControls to get all container controls
      */
-    targetControl?: Control;
+    targetControl: Control;
 
     /**
      * The container controls to which the View or ComponentContainer instances are added.
      */
-    targetControls?: Control[];
+    targetControls: Control[];
   }
 
   /**
@@ -39983,12 +39983,12 @@ declare module "sap/ui/core/routing/Router" {
     /**
      * The current displayed title
      */
-    title?: string;
+    title: string;
 
     /**
      * An array which contains the history of previous titles
      */
-    history?: any[];
+    history: any[];
 
     /**
      * An array which contains the title history information of the current router and of the router of the
@@ -39997,12 +39997,12 @@ declare module "sap/ui/core/routing/Router" {
      * control), the application can simply use the `nestedHistory` to build up the control and doesn't need
      * the `history` anymore.
      */
-    nestedHistory?: any[];
+    nestedHistory: any[];
 
     /**
      * Whether the titleChanged event is triggered by a nested component
      */
-    propagated?: boolean;
+    propagated: boolean;
   }
 
   /**
@@ -40587,32 +40587,32 @@ declare module "sap/ui/core/routing/Targets" {
     /**
      * The view that got displayed.
      */
-    view?: object;
+    view: object;
 
     /**
      * The control that now contains the view in the controlAggregation
      */
-    control?: object;
+    control: object;
 
     /**
      * The options object passed to the constructor {@link sap.ui.core.routing.Targets#constructor}
      */
-    config?: object;
+    config: object;
 
     /**
      * The name of the target firing the event
      */
-    name?: object;
+    name: object;
 
     /**
      * The data passed into the {@link sap.ui.core.routing.Targets#display} function
      */
-    data?: object;
+    data: object;
 
     /**
      * Whether the target is relevant to the matched route or not
      */
-    routeRelevant?: object;
+    routeRelevant: object;
   }
 
   /**
@@ -40630,12 +40630,12 @@ declare module "sap/ui/core/routing/Targets" {
     /**
      * The current displayed title
      */
-    title?: string;
+    title: string;
 
     /**
      * The name of the displayed target
      */
-    name?: string;
+    name: string;
   }
 
   /**
@@ -40778,12 +40778,12 @@ declare module "sap/ui/core/routing/Views" {
     /**
      * the instance of the created view.
      */
-    view?: View;
+    view: View;
 
     /**
      * The view options passed to {@link sap.ui.view}
      */
-    viewOptions?: object;
+    viewOptions: object;
   }
 
   /**
@@ -41152,22 +41152,22 @@ declare module "sap/ui/core/ScrollBar" {
     /**
      * Actions are: Click on track, button, drag of thumb, or mouse wheel click.
      */
-    action?: ScrollBarAction | keyof typeof ScrollBarAction;
+    action: ScrollBarAction | keyof typeof ScrollBarAction;
 
     /**
      * Direction of scrolling: back (up) or forward (down).
      */
-    forward?: boolean;
+    forward: boolean;
 
     /**
      * Current Scroll position either in pixels or in steps.
      */
-    newScrollPos?: int;
+    newScrollPos: int;
 
     /**
      * Old Scroll position - can be in pixels or in steps.
      */
-    oldScrollPos?: int;
+    oldScrollPos: int;
   }
 
   /**
@@ -47625,7 +47625,7 @@ declare module "sap/ui/core/ws/SapPcpWebSocket" {
     /**
      * Received pcpFields as a key-value map.
      */
-    pcpFields?: string;
+    pcpFields: string;
   }
 
   /**
@@ -48066,17 +48066,17 @@ declare module "sap/ui/core/ws/WebSocket" {
     /**
      * Close code provided by the server.
      */
-    code?: string;
+    code: string;
 
     /**
      * Reason from server for closing the connection.
      */
-    reason?: string;
+    reason: string;
 
     /**
      * Indicates whether the connection was cleanly closed or not.
      */
-    wasClean?: string;
+    wasClean: string;
   }
 
   /**
@@ -48107,7 +48107,7 @@ declare module "sap/ui/core/ws/WebSocket" {
     /**
      * Received data from the server.
      */
-    data?: string;
+    data: string;
   }
 
   /**
@@ -56710,19 +56710,19 @@ declare module "sap/ui/model/Model" {
    * Parameters of the Model#parseError event.
    */
   export interface Model$ParseErrorEventParameters {
-    errorCode?: int;
+    errorCode: int;
 
-    url?: string;
+    url: string;
 
-    reason?: string;
+    reason: string;
 
-    srcText?: string;
+    srcText: string;
 
-    line?: int;
+    line: int;
 
-    linepos?: int;
+    linepos: int;
 
-    filepos?: int;
+    filepos: int;
   }
 
   /**
@@ -56740,12 +56740,12 @@ declare module "sap/ui/model/Model" {
     /**
      * The cause of the property value change
      */
-    reason?: ChangeReason;
+    reason: ChangeReason;
 
     /**
      * The path of the property
      */
-    path?: string;
+    path: string;
 
     /**
      * The binding context (if available)
@@ -56755,7 +56755,7 @@ declare module "sap/ui/model/Model" {
     /**
      * The current value of the property
      */
-    value?: any;
+    value: any;
   }
 
   /**
@@ -56773,7 +56773,7 @@ declare module "sap/ui/model/Model" {
     /**
      * URL which was sent to the back end
      */
-    url?: string;
+    url: string;
 
     /**
      * Type of the request (if available)
@@ -56784,7 +56784,7 @@ declare module "sap/ui/model/Model" {
      * Whether the request has been successful or not. In case of errors, consult the optional `errorobject`
      * parameter.
      */
-    success?: boolean;
+    success: boolean;
 
     /**
      * If the request failed the error if any can be accessed in this property.
@@ -56822,17 +56822,17 @@ declare module "sap/ui/model/Model" {
     /**
      * A text that describes the failure.
      */
-    message?: string;
+    message: string;
 
     /**
      * HTTP status code returned by the request (if available)
      */
-    statusCode?: string;
+    statusCode: string;
 
     /**
      * The status as a text, details not specified, intended only for diagnosis output
      */
-    statusText?: string;
+    statusText: string;
 
     /**
      * Response that has been received for the request, as a text string
@@ -56855,7 +56855,7 @@ declare module "sap/ui/model/Model" {
     /**
      * The url which is sent to the back end
      */
-    url?: string;
+    url: string;
 
     /**
      * The type of the request (if available)
@@ -68591,7 +68591,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * An array of Errors
      */
-    result?: Error[];
+    result: Error[];
   }
 
   /**
@@ -68610,7 +68610,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
      * An array consisting of one or several annotation sources and/or errors containing a source property and
      * error details.
      */
-    result?: Source[];
+    result: Source[];
   }
 
   /**
@@ -68628,44 +68628,44 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The request ID
      */
-    ID?: string;
+    ID: string;
 
     /**
      * The URL which is sent to the backend
      */
-    url?: string;
+    url: string;
 
     /**
      * The HTTP method
      */
-    method?: string;
+    method: string;
 
     /**
      * The request headers
      */
-    headers?: Record<string, string>;
+    headers: Record<string, string>;
 
     /**
      * Request was successful or not
      */
-    success?: boolean;
+    success: boolean;
 
     /**
      * If the request is synchronous or asynchronous (if available)
      */
-    async?: boolean;
+    async: boolean;
 
     /**
      * Array of embedded requests ($batch) Each request object within the array contains the following properties:
      * url, method, headers, response object
      */
-    requests?: any[];
+    requests: any[];
 
     /**
      * The response object - empty object if no response: The response object contains the following properties:
      * message, success, headers, statusCode, statusText, responseText
      */
-    response?: object;
+    response: object;
   }
 
   /**
@@ -68683,44 +68683,44 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The request ID
      */
-    ID?: string;
+    ID: string;
 
     /**
      * The URL which is sent to the backend
      */
-    url?: string;
+    url: string;
 
     /**
      * The HTTP method
      */
-    method?: string;
+    method: string;
 
     /**
      * The request headers
      */
-    headers?: Record<string, string>;
+    headers: Record<string, string>;
 
     /**
      * If the request is synchronous or asynchronous (if available)
      */
-    async?: boolean;
+    async: boolean;
 
     /**
      * Request was successful or not
      */
-    success?: boolean;
+    success: boolean;
 
     /**
      * The response object - empty object if no response The response object contains the following properties:
      * message, success, headers, statusCode, statusText, responseText
      */
-    response?: object;
+    response: object;
 
     /**
      * Array of embedded requests ($batch) Each request object within the array contains the following properties:
      * url, method, headers, response object
      */
-    requests?: any[];
+    requests: any[];
   }
 
   /**
@@ -68738,7 +68738,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The URL which is sent to the backend
      */
-    url?: string;
+    url: string;
 
     /**
      * The type of the request (if available)
@@ -68754,7 +68754,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
      * Array of embedded requests ($batch) Each request object within the array contains the following properties:
      * url, method, headers
      */
-    requests?: any[];
+    requests: any[];
   }
 
   /**
@@ -68772,32 +68772,32 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The parsed metadata
      */
-    metadata?: string;
+    metadata: string;
 
     /**
      * A text that describes the failure.
      */
-    message?: string;
+    message: string;
 
     /**
      * HTTP status code returned by the request (if available)
      */
-    statusCode?: string;
+    statusCode: string;
 
     /**
      * The status as a text, details not specified, intended only for diagnosis output
      */
-    statusText?: string;
+    statusText: string;
 
     /**
      * Response that has been received for the request, as a text string
      */
-    responseText?: string;
+    responseText: string;
 
     /**
      * The response object - empty object if no response
      */
-    response?: object;
+    response: object;
   }
 
   /**
@@ -68815,7 +68815,7 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The parsed metadata
      */
-    metadata?: string;
+    metadata: string;
   }
 
   /**
@@ -68833,23 +68833,23 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The request ID
      */
-    ID?: string;
+    ID: string;
 
     /**
      * The HTTP method
      */
-    method?: string;
+    method: string;
 
     /**
      * The request headers
      */
-    headers?: Record<string, string>;
+    headers: Record<string, string>;
 
     /**
      * The response object - empty object if no response: The response object contains the following properties:
      * message, success, headers, statusCode, statusText, responseText
      */
-    response?: object;
+    response: object;
   }
 
   /**
@@ -68867,38 +68867,38 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The request ID
      */
-    ID?: string;
+    ID: string;
 
     /**
      * The URL which is sent to the backend
      */
-    url?: string;
+    url: string;
 
     /**
      * The HTTP method
      */
-    method?: string;
+    method: string;
 
     /**
      * The request headers
      */
-    headers?: Record<string, string>;
+    headers: Record<string, string>;
 
     /**
      * If the request is synchronous or asynchronous (if available)
      */
-    async?: boolean;
+    async: boolean;
 
     /**
      * Request was successful or not
      */
-    success?: boolean;
+    success: boolean;
 
     /**
      * The response object - empty object if no response The response object contains the following properties:
      * message, success, headers, statusCode, statusText, responseText
      */
-    response?: object;
+    response: object;
   }
 
   /**
@@ -68916,17 +68916,17 @@ declare module "sap/ui/model/odata/v2/ODataModel" {
     /**
      * The request ID
      */
-    ID?: string;
+    ID: string;
 
     /**
      * The HTTP method
      */
-    method?: string;
+    method: string;
 
     /**
      * The request headers
      */
-    headers?: Record<string, string>;
+    headers: Record<string, string>;
   }
 
   /**
@@ -71104,7 +71104,7 @@ declare module "sap/ui/model/odata/v4/ODataContextBinding" {
     /**
      * Whether all PATCHes are successfully processed
      */
-    success?: boolean;
+    success: boolean;
   }
 
   /**
@@ -72268,7 +72268,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
      * reason "AddVirtualContext" and then removed with detailed reason "RemoveVirtualContext" (since 1.69.0);
      * `undefined` is used in all other cases
      */
-    detailedReason?: string;
+    detailedReason: string;
   }
 
   /**
@@ -72286,7 +72286,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     /**
      * The affected context
      */
-    context?: Context;
+    context: Context;
   }
 
   /**
@@ -72304,12 +72304,12 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     /**
      * The context for the created entity
      */
-    context?: Context;
+    context: Context;
 
     /**
      * Whether the POST was successfully processed; in case of an error, the error is already reported to {@link sap.ui.core.Messaging}
      */
-    success?: boolean;
+    success: boolean;
   }
 
   /**
@@ -72327,7 +72327,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     /**
      * The context for the created entity
      */
-    context?: Context;
+    context: Context;
   }
 
   /**
@@ -72377,7 +72377,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
     /**
      * Whether all PATCHes are successfully processed
      */
-    success?: boolean;
+    success: boolean;
   }
 
   /**
@@ -72418,7 +72418,7 @@ declare module "sap/ui/model/odata/v4/ODataListBinding" {
      * leads to the "strongest" change reason in the order {@link sap.ui.model.ChangeReason.Filter Filter},
      * {@link sap.ui.model.ChangeReason.Sort Sort}, {@link sap.ui.model.ChangeReason.Refresh Refresh}, {@link sap.ui.model.ChangeReason.Change Change}.
      */
-    reason?: ChangeReason;
+    reason: ChangeReason;
   }
 
   /**
@@ -74370,7 +74370,7 @@ declare module "sap/ui/model/odata/v4/ODataModel" {
     /**
      * The property binding's {@link sap.ui.model.Binding#getResolvedPath resolved path}
      */
-    resolvedPath?: string;
+    resolvedPath: string;
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.layout.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.layout.d.ts
@@ -3778,7 +3778,7 @@ declare module "sap/ui/layout/cssgrid/GridResponsiveLayout" {
     /**
      * The name of the newly active layout aggregation
      */
-    layout?: string;
+    layout: string;
   }
 
   /**
@@ -4510,7 +4510,7 @@ declare module "sap/ui/layout/cssgrid/ResponsiveColumnLayout" {
     /**
      * The name of the newly active layout - "S", "M", "ML", "L", "XL", "XXL" or "XXXL".
      */
-    layout?: string;
+    layout: string;
   }
 
   /**
@@ -5239,7 +5239,7 @@ declare module "sap/ui/layout/DynamicSideContent" {
    * Parameters of the DynamicSideContent#breakpointChanged event.
    */
   export interface DynamicSideContent$BreakpointChangedEventParameters {
-    currentBreakpoint?: string;
+    currentBreakpoint: string;
   }
 
   /**
@@ -13080,12 +13080,12 @@ declare module "sap/ui/layout/PaneContainer" {
     /**
      * An array of values representing the old (pixel)sizes of the split panes, which are inside the pane container.
      */
-    oldSizes?: float[];
+    oldSizes: float[];
 
     /**
      * An array of values representing the new (pixel)sizes of the split panes, which are inside the pane container.
      */
-    newSizes?: float[];
+    newSizes: float[];
   }
 
   /**
@@ -14530,17 +14530,17 @@ declare module "sap/ui/layout/Splitter" {
      * The ID of the splitter control. The splitter control can also be accessed by calling getSource() on the
      * event.
      */
-    id?: string;
+    id: string;
 
     /**
      * An array of values representing the old (pixel-)sizes of the splitter contents
      */
-    oldSizes?: int[];
+    oldSizes: int[];
 
     /**
      * An array of values representing the new (pixel-)sizes of the splitter contents
      */
-    newSizes?: int[];
+    newSizes: int[];
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.unified.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.unified.d.ts
@@ -1812,12 +1812,12 @@ declare module "sap/ui/unified/Calendar" {
     /**
      * The selected week number.
      */
-    weekNumber?: int;
+    weekNumber: int;
 
     /**
      * The days of the corresponding week that are selected or deselected.
      */
-    weekDays?: DateRange;
+    weekDays: DateRange;
   }
 
   /**
@@ -4451,17 +4451,17 @@ declare module "sap/ui/unified/calendar/Month" {
     /**
      * focused date
      */
-    date?: object;
+    date: object;
 
     /**
      * focused date is in an other month than the displayed one
      */
-    otherMonth?: boolean;
+    otherMonth: boolean;
 
     /**
      * focused date is set to the same as before (date in other month clicked)
      */
-    restoreOldDate?: boolean;
+    restoreOldDate: boolean;
   }
 
   /**
@@ -4486,14 +4486,14 @@ declare module "sap/ui/unified/calendar/Month" {
     /**
      * The selected week number.
      */
-    weekNumber?: int;
+    weekNumber: int;
 
     /**
      * The days of the corresponding week that are selected or deselected.
      *
      * **Note:** Will be set to `null` if that week is being deselected.
      */
-    weekDays?: DateRange;
+    weekDays: DateRange;
   }
 
   /**
@@ -6037,12 +6037,12 @@ declare module "sap/ui/unified/calendar/MonthsRow" {
     /**
      * First date, as UI5Date or JavaScript Date object, of the month that is focused.
      */
-    date?: object;
+    date: object;
 
     /**
      * If set, the focused date is not rendered yet. (This happens by navigating out of the visible area.)
      */
-    notVisible?: boolean;
+    notVisible: boolean;
   }
 
   /**
@@ -6941,12 +6941,12 @@ declare module "sap/ui/unified/calendar/TimesRow" {
     /**
      * date, as UI5Date or JavaScript Date object, of the focused time.
      */
-    date?: object;
+    date: object;
 
     /**
      * If set, the focused date is not rendered yet. (This happens by navigating out of the visible area.)
      */
-    notVisible?: boolean;
+    notVisible: boolean;
   }
 
   /**
@@ -11400,17 +11400,17 @@ declare module "sap/ui/unified/CalendarRow" {
     /**
      * Interval start date as UI5Date or JavaScript Date object
      */
-    startDate?: object;
+    startDate: object;
 
     /**
      * Interval end date as UI5Date or JavaScript Date object
      */
-    endDate?: object;
+    endDate: object;
 
     /**
      * If set, the selected interval is a subinterval
      */
-    subInterval?: boolean;
+    subInterval: boolean;
   }
 
   /**
@@ -11428,7 +11428,7 @@ declare module "sap/ui/unified/CalendarRow" {
     /**
      * The type of the event that triggers this `leaveRow`
      */
-    type?: string;
+    type: string;
   }
 
   /**
@@ -11446,23 +11446,23 @@ declare module "sap/ui/unified/CalendarRow" {
     /**
      * selected appointment
      */
-    appointment?: CalendarAppointment;
+    appointment: CalendarAppointment;
 
     /**
      * selected appointments in case a group appointment is selected
      */
-    appointments?: CalendarAppointment[];
+    appointments: CalendarAppointment[];
 
     /**
      * If set, the appointment was selected by multiple selection (e.g. shift + mouse click). So more than the
      * current appointment could be selected.
      */
-    multiSelect?: boolean;
+    multiSelect: boolean;
 
     /**
      * Gives the ID of the DOM element of the clicked appointment
      */
-    domRefId?: string;
+    domRefId: string;
   }
 
   /**
@@ -12932,47 +12932,47 @@ declare module "sap/ui/unified/ColorPicker" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -12990,47 +12990,47 @@ declare module "sap/ui/unified/ColorPicker" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -13489,47 +13489,47 @@ declare module "sap/ui/unified/ColorPickerPopover" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -13547,47 +13547,47 @@ declare module "sap/ui/unified/ColorPickerPopover" {
     /**
      * Parameter containing the RED value (0-255).
      */
-    r?: int;
+    r: int;
 
     /**
      * Parameter containing the GREEN value (0-255).
      */
-    g?: int;
+    g: int;
 
     /**
      * Parameter containing the BLUE value (0-255).
      */
-    b?: int;
+    b: int;
 
     /**
      * Parameter containing the HUE value (0-360).
      */
-    h?: int;
+    h: int;
 
     /**
      * Parameter containing the SATURATION value (0-100).
      */
-    s?: int;
+    s: int;
 
     /**
      * Parameter containing the VALUE value (0-100).
      */
-    v?: int;
+    v: int;
 
     /**
      * Parameter containing the LIGHTNESS value (0-100).
      */
-    l?: int;
+    l: int;
 
     /**
      * Parameter containing the Hexadecimal string (#FFFFFF).
      */
-    hex?: string;
+    hex: string;
 
     /**
      * Parameter containing the alpha value (transparency).
      */
-    alpha?: string;
+    alpha: string;
   }
 
   /**
@@ -17322,12 +17322,12 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * New file path value.
      */
-    newValue?: string;
+    newValue: string;
 
     /**
      * Files.
      */
-    files?: object[];
+    files: object[];
   }
 
   /**
@@ -17358,7 +17358,7 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of the file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
   }
 
   /**
@@ -17376,7 +17376,7 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The filename, which is longer than specified by the value of the property `maximumFilenameLength`.
      */
-    fileName?: string;
+    fileName: string;
   }
 
   /**
@@ -17394,12 +17394,12 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * The size in MB of a file to be uploaded.
      */
-    fileSize?: string;
+    fileSize: string;
   }
 
   /**
@@ -17417,17 +17417,17 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * The file ending of a file to be uploaded.
      */
-    fileType?: string;
+    fileType: string;
 
     /**
      * The MIME type of a file to be uploaded.
      */
-    mimeType?: string;
+    mimeType: string;
   }
 
   /**
@@ -17445,7 +17445,7 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * Http-Request-Headers.
@@ -17453,7 +17453,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving `requestHeader` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    requestHeaders?: object[];
+    requestHeaders: object[];
   }
 
   /**
@@ -17471,7 +17471,7 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * Response message which comes from the server.
@@ -17480,7 +17480,7 @@ declare module "sap/ui/unified/FileUploader" {
      * of the iFrame. It can consist of a return code and an optional message. This does not work in cross-domain
      * scenarios.
      */
-    response?: string;
+    response: string;
 
     /**
      * ReadyState of the XHR request.
@@ -17488,7 +17488,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving a `readyStateXHR` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    readyStateXHR?: string;
+    readyStateXHR: string;
 
     /**
      * Status of the XHR request.
@@ -17496,7 +17496,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving a `status` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    status?: string;
+    status: string;
 
     /**
      * Http-Response which comes from the server.
@@ -17505,7 +17505,7 @@ declare module "sap/ui/unified/FileUploader" {
      *
      * This property is not supported by Internet Explorer 9.
      */
-    responseRaw?: string;
+    responseRaw: string;
 
     /**
      * Http-Response-Headers which come from the server.
@@ -17516,7 +17516,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving `headers` is to set the property `sendXHR` to true. This property is not supported
      * by Internet Explorer 9.
      */
-    headers?: object;
+    headers: object;
 
     /**
      * Http-Request-Headers.
@@ -17524,7 +17524,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving `requestHeaders` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    requestHeaders?: object[];
+    requestHeaders: object[];
   }
 
   /**
@@ -17542,22 +17542,22 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * Indicates whether or not the relative upload progress can be calculated out of loaded and total.
      */
-    lengthComputable?: boolean;
+    lengthComputable: boolean;
 
     /**
      * The number of bytes of the file which have been uploaded by the time the event was fired.
      */
-    loaded?: float;
+    loaded: float;
 
     /**
      * The total size of the file to be uploaded in bytes.
      */
-    total?: float;
+    total: float;
 
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * Http-Request-Headers.
@@ -17565,7 +17565,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving `requestHeaders` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    requestHeaders?: object[];
+    requestHeaders: object[];
   }
 
   /**
@@ -17583,7 +17583,7 @@ declare module "sap/ui/unified/FileUploader" {
     /**
      * The name of a file to be uploaded.
      */
-    fileName?: string;
+    fileName: string;
 
     /**
      * Http-Request-Headers.
@@ -17591,7 +17591,7 @@ declare module "sap/ui/unified/FileUploader" {
      * Required for receiving `requestHeaders` is to set the property `sendXHR` to true. This property is not
      * supported by Internet Explorer 9.
      */
-    requestHeaders?: object[];
+    requestHeaders: object[];
   }
 
   /**
@@ -18447,7 +18447,7 @@ declare module "sap/ui/unified/Menu" {
     /**
      * The action (item) which was selected by the user.
      */
-    item?: MenuItemBase;
+    item: MenuItemBase;
   }
 
   /**
@@ -19041,7 +19041,7 @@ declare module "sap/ui/unified/MenuItemBase" {
     /**
      * The current item
      */
-    item?: MenuItemBase;
+    item: MenuItemBase;
   }
 
   /**

--- a/test-packages/openui5-snapshot-test/test/event-params-optionality-spec.js
+++ b/test-packages/openui5-snapshot-test/test/event-params-optionality-spec.js
@@ -1,0 +1,863 @@
+"use strict";
+
+const assert = require("assert");
+
+describe("event parameter optionality", function () {
+  this.timeout(10000);
+
+  let generateFromObjects;
+
+  before(async () => {
+    ({ generateFromObjects } = await import("@ui5/dts-generator"));
+  });
+
+  const directives = {
+    badSymbols: [],
+    badMethods: [],
+    badInterfaces: [],
+    typeTyposMap: {},
+    namespacesToInterfaces: {},
+    forwardDeclarations: {},
+    fqnToIgnore: {},
+    overlays: {},
+    deprecatedEnumAliases: {},
+    modulesWithNamedExports: [],
+    eventsWithAllParamsOptional: [],
+  };
+
+  function makeEvent(name, parameterProperties) {
+    return {
+      name,
+      visibility: "public",
+      parameters: [
+        {
+          name: "oControlEvent",
+          type: "sap.ui.base.Event",
+          parameterProperties: {
+            getSource: {
+              name: "getSource",
+              type: "sap.ui.base.EventProvider",
+              optional: false,
+            },
+            getParameters: {
+              name: "getParameters",
+              type: "object",
+              optional: false,
+              parameterProperties,
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  function findPropertyLine(dtsText, propName) {
+    return dtsText
+      .split("\n")
+      .find(
+        (l) =>
+          l.includes(propName) &&
+          l.includes(":") &&
+          !l.includes("/**") &&
+          !l.includes("*"),
+      );
+  }
+
+  async function generate(apiObject, dependencyApiObjects, customDirectives) {
+    return generateFromObjects({
+      apiObject,
+      dependencyApiObjects,
+      directives: customDirectives || directives,
+    });
+  }
+
+  describe("default behavior (trusts source data)", function () {
+    const baseLibApi = {
+      library: "sap.ui.core",
+      version: "1.0.0",
+      symbols: [
+        {
+          kind: "namespace",
+          name: "sap.ui.base",
+          basename: "base",
+          resource: "sap/ui/base/library.js",
+          module: "sap/ui/base/library",
+          export: "",
+          visibility: "public",
+          description: "",
+        },
+        {
+          kind: "class",
+          name: "sap.ui.base.EventProvider",
+          basename: "EventProvider",
+          resource: "sap/ui/base/EventProvider.js",
+          module: "sap/ui/base/EventProvider",
+          export: "",
+          visibility: "public",
+          abstract: true,
+          description: "Base event provider.",
+          methods: [
+            {
+              name: "attachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "oData", type: "object", optional: true },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "detachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "fireEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "mParameters", type: "object", optional: true },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    function makeTestLib(events) {
+      return {
+        library: "testlib",
+        version: "1.0.0",
+        symbols: [
+          {
+            kind: "namespace",
+            name: "testlib",
+            basename: "testlib",
+            resource: "testlib/library.js",
+            module: "testlib/library",
+            export: "",
+            visibility: "public",
+            description: "",
+          },
+          {
+            kind: "class",
+            name: "testlib.MyClass",
+            basename: "MyClass",
+            resource: "testlib/MyClass.js",
+            module: "testlib/MyClass",
+            export: "",
+            visibility: "public",
+            extends: "sap.ui.base.EventProvider",
+            description: "A test class extending EventProvider.",
+            events,
+            methods: [
+              {
+                name: "attachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "fireChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    it("parameters with optional: false become required", async () => {
+      const event = makeEvent("change", {
+        selectedItem: {
+          name: "selectedItem",
+          type: "string",
+          optional: false,
+          description: "The selected item.",
+        },
+      });
+
+      const result = await generate(makeTestLib([event]), [baseLibApi]);
+
+      const selectedItemLine = findPropertyLine(result.dtsText, "selectedItem");
+      assert.ok(selectedItemLine, "selectedItem should appear in output");
+      assert.ok(
+        !selectedItemLine.includes("?"),
+        `selectedItem should be required (no '?'), got: "${selectedItemLine.trim()}"`,
+      );
+    });
+
+    it("parameters with optional: true stay optional", async () => {
+      const event = makeEvent("change", {
+        selectedItem: {
+          name: "selectedItem",
+          type: "string",
+          optional: true,
+          description: "The selected item.",
+        },
+      });
+
+      const result = await generate(makeTestLib([event]), [baseLibApi]);
+
+      assert.match(result.dtsText, /selectedItem\?/);
+    });
+
+    it("mixed: optional: false → required, optional: true → optional", async () => {
+      const event = makeEvent("change", {
+        selectedItem: {
+          name: "selectedItem",
+          type: "string",
+          optional: false,
+          description: "The selected item.",
+        },
+        value: {
+          name: "value",
+          type: "string",
+          optional: true,
+          description: "The value.",
+        },
+      });
+
+      const result = await generate(makeTestLib([event]), [baseLibApi]);
+
+      const selectedItemLine = findPropertyLine(result.dtsText, "selectedItem");
+      const valueLine = findPropertyLine(result.dtsText, "value");
+
+      assert.ok(selectedItemLine, "selectedItem should appear in output");
+      assert.ok(valueLine, "value should appear in output");
+      assert.ok(
+        !selectedItemLine.includes("?"),
+        `selectedItem should be required (no '?'), got: "${selectedItemLine.trim()}"`,
+      );
+      assert.ok(
+        valueLine.includes("?"),
+        `value should be optional (has '?'), got: "${valueLine.trim()}"`,
+      );
+    });
+
+    // All parameters should have optional: true or false in practice;
+    // this test documents the defensive fallback behavior (treated as optional).
+    it("parameters without optional field default to optional", async () => {
+      const event = makeEvent("change", {
+        source: {
+          name: "source",
+          type: "string",
+          description: "The event source.",
+        },
+      });
+
+      const result = await generate(makeTestLib([event]), [baseLibApi]);
+
+      assert.match(result.dtsText, /source\?/);
+    });
+  });
+
+  describe("eventsWithAllParamsOptional deny-list", function () {
+    const baseLibApi = {
+      library: "sap.ui.core",
+      version: "1.0.0",
+      symbols: [
+        {
+          kind: "namespace",
+          name: "sap.ui.base",
+          basename: "base",
+          resource: "sap/ui/base/library.js",
+          module: "sap/ui/base/library",
+          export: "",
+          visibility: "public",
+          description: "",
+        },
+        {
+          kind: "class",
+          name: "sap.ui.base.EventProvider",
+          basename: "EventProvider",
+          resource: "sap/ui/base/EventProvider.js",
+          module: "sap/ui/base/EventProvider",
+          export: "",
+          visibility: "public",
+          abstract: true,
+          description: "Base event provider.",
+          methods: [
+            {
+              name: "attachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "oData", type: "object", optional: true },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "detachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "fireEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "mParameters", type: "object", optional: true },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    function makeTestLib(events) {
+      return {
+        library: "testlib",
+        version: "1.0.0",
+        symbols: [
+          {
+            kind: "namespace",
+            name: "testlib",
+            basename: "testlib",
+            resource: "testlib/library.js",
+            module: "testlib/library",
+            export: "",
+            visibility: "public",
+            description: "",
+          },
+          {
+            kind: "class",
+            name: "testlib.MyClass",
+            basename: "MyClass",
+            resource: "testlib/MyClass.js",
+            module: "testlib/MyClass",
+            export: "",
+            visibility: "public",
+            extends: "sap.ui.base.EventProvider",
+            description: "A test class extending EventProvider.",
+            events,
+            methods: [
+              {
+                name: "attachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "fireChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    it("deny-listed event has all parameters optional", async () => {
+      const event = makeEvent("change", {
+        selectedItem: {
+          name: "selectedItem",
+          type: "string",
+          optional: false,
+          description: "The selected item.",
+        },
+        value: {
+          name: "value",
+          type: "string",
+          optional: true,
+          description: "The value.",
+        },
+      });
+
+      const denyListDirectives = {
+        ...directives,
+        eventsWithAllParamsOptional: ["testlib.MyClass:change"],
+      };
+
+      const result = await generate(
+        makeTestLib([event]),
+        [baseLibApi],
+        denyListDirectives,
+      );
+
+      assert.match(result.dtsText, /selectedItem\?/);
+      assert.match(result.dtsText, /value\?/);
+    });
+
+    it("deny-list only affects listed events", async () => {
+      const apiObject = {
+        library: "testlib",
+        version: "1.0.0",
+        symbols: [
+          {
+            kind: "namespace",
+            name: "testlib",
+            basename: "testlib",
+            resource: "testlib/library.js",
+            module: "testlib/library",
+            export: "",
+            visibility: "public",
+            description: "",
+          },
+          {
+            kind: "class",
+            name: "testlib.MyClass",
+            basename: "MyClass",
+            resource: "testlib/MyClass.js",
+            module: "testlib/MyClass",
+            export: "",
+            visibility: "public",
+            extends: "sap.ui.base.EventProvider",
+            description: "A test class.",
+            events: [
+              makeEvent("change", {
+                selectedItem: {
+                  name: "selectedItem",
+                  type: "string",
+                  optional: false,
+                  description: "The selected item.",
+                },
+              }),
+              makeEvent("press", {
+                source: {
+                  name: "source",
+                  type: "string",
+                  optional: false,
+                  description: "The source.",
+                },
+              }),
+            ],
+            methods: [
+              {
+                name: "attachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "fireChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "attachPress",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachPress",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "firePress",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const denyListDirectives = {
+        ...directives,
+        eventsWithAllParamsOptional: ["testlib.MyClass:change"],
+      };
+
+      const result = await generate(
+        apiObject,
+        [baseLibApi],
+        denyListDirectives,
+      );
+
+      // "change" is deny-listed → selectedItem stays optional
+      assert.match(result.dtsText, /selectedItem\?/);
+
+      // "press" is NOT deny-listed → source becomes required
+      const sourceLine = findPropertyLine(result.dtsText, "source");
+      assert.ok(sourceLine, "source should appear in output");
+      assert.ok(
+        !sourceLine.includes("?"),
+        `source should be required (no '?'), got: "${sourceLine.trim()}"`,
+      );
+    });
+  });
+
+  describe("inheritance", function () {
+    const baseLibApi = {
+      library: "sap.ui.core",
+      version: "4.0.0",
+      symbols: [
+        {
+          kind: "namespace",
+          name: "sap.ui.base",
+          basename: "base",
+          resource: "sap/ui/base/library.js",
+          module: "sap/ui/base/library",
+          export: "",
+          visibility: "public",
+          description: "",
+        },
+        {
+          kind: "class",
+          name: "sap.ui.base.EventProvider",
+          basename: "EventProvider",
+          resource: "sap/ui/base/EventProvider.js",
+          module: "sap/ui/base/EventProvider",
+          export: "",
+          visibility: "public",
+          abstract: true,
+          description: "Base event provider.",
+          methods: [
+            {
+              name: "attachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "oData", type: "object", optional: true },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "detachEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "fireEvent",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "sEventId", type: "string", optional: false },
+                { name: "mParameters", type: "object", optional: true },
+              ],
+            },
+          ],
+        },
+        {
+          kind: "class",
+          name: "sap.ui.base.Parent",
+          basename: "Parent",
+          resource: "sap/ui/base/Parent.js",
+          module: "sap/ui/base/Parent",
+          export: "",
+          visibility: "public",
+          extends: "sap.ui.base.EventProvider",
+          description: "A parent class with a change event.",
+          events: [
+            makeEvent("change", {
+              value: {
+                name: "value",
+                type: "string",
+                optional: false,
+                description: "The value.",
+              },
+            }),
+          ],
+          methods: [
+            {
+              name: "attachChange",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "oData", type: "object", optional: true },
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "detachChange",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "fnFunction", type: "function", optional: false },
+                { name: "oListener", type: "object", optional: true },
+              ],
+            },
+            {
+              name: "fireChange",
+              visibility: "public",
+              returnValue: { type: "this" },
+              parameters: [
+                { name: "mParameters", type: "object", optional: true },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    it("inherited parameters are not redeclared in child interface", async () => {
+      const childEvent = makeEvent("change", {
+        value: {
+          name: "value",
+          type: "string",
+          optional: false,
+          description: "The value.",
+        },
+        extra: {
+          name: "extra",
+          type: "string",
+          optional: false,
+          description: "Extra param added by child.",
+        },
+      });
+
+      const apiObject = {
+        library: "testlib",
+        version: "1.0.0",
+        symbols: [
+          {
+            kind: "namespace",
+            name: "testlib",
+            basename: "testlib",
+            resource: "testlib/library.js",
+            module: "testlib/library",
+            export: "",
+            visibility: "public",
+            description: "",
+          },
+          {
+            kind: "class",
+            name: "testlib.Child",
+            basename: "Child",
+            resource: "testlib/Child.js",
+            module: "testlib/Child",
+            export: "",
+            visibility: "public",
+            extends: "sap.ui.base.Parent",
+            description: "A child class.",
+            events: [childEvent],
+            methods: [
+              {
+                name: "attachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "fireChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = await generate(apiObject, [baseLibApi]);
+
+      // "extra" is new in the child → required (optional: false, no deny-list)
+      const extraLine = findPropertyLine(result.dtsText, "extra");
+      assert.ok(extraLine, "extra should appear in output");
+      assert.ok(
+        !extraLine.includes("?"),
+        `extra should be required (no '?'), got: "${extraLine.trim()}"`,
+      );
+
+      // "value" is inherited from parent → not redeclared in child interface
+      assert.ok(
+        !findPropertyLine(result.dtsText, "value"),
+        "value should NOT appear in child interface (it is inherited from parent)",
+      );
+
+      // The child interface should extend the parent interface
+      assert.match(
+        result.dtsText,
+        /Child\$ChangeEventParameters extends Parent\$ChangeEventParameters/,
+      );
+    });
+
+    it("parent deny-listed: inherited params stay optional, child's new params are required", async () => {
+      const childEvent = makeEvent("change", {
+        value: {
+          name: "value",
+          type: "string",
+          optional: false,
+          description: "The value.",
+        },
+        extra: {
+          name: "extra",
+          type: "string",
+          optional: false,
+          description: "Extra param added by child.",
+        },
+      });
+
+      const apiObject = {
+        library: "testlib",
+        version: "1.0.0",
+        symbols: [
+          {
+            kind: "namespace",
+            name: "testlib",
+            basename: "testlib",
+            resource: "testlib/library.js",
+            module: "testlib/library",
+            export: "",
+            visibility: "public",
+            description: "",
+          },
+          {
+            kind: "class",
+            name: "testlib.Child",
+            basename: "Child",
+            resource: "testlib/Child.js",
+            module: "testlib/Child",
+            export: "",
+            visibility: "public",
+            extends: "sap.ui.base.Parent",
+            description: "A child class.",
+            events: [childEvent],
+            methods: [
+              {
+                name: "attachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "oData", type: "object", optional: true },
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "detachChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "fnFunction", type: "function", optional: false },
+                  { name: "oListener", type: "object", optional: true },
+                ],
+              },
+              {
+                name: "fireChange",
+                visibility: "public",
+                returnValue: { type: "this" },
+                parameters: [
+                  { name: "mParameters", type: "object", optional: true },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const denyListDirectives = {
+        ...directives,
+        eventsWithAllParamsOptional: ["sap.ui.base.Parent:change"],
+      };
+
+      const result = await generate(apiObject, [baseLibApi], denyListDirectives);
+
+      // "extra" is new in the child (not deny-listed) → required
+      const extraLine = findPropertyLine(result.dtsText, "extra");
+      assert.ok(extraLine, "extra should appear in output");
+      assert.ok(
+        !extraLine.includes("?"),
+        `extra should be required (no '?'), got: "${extraLine.trim()}"`,
+      );
+
+      // child extends parent interface
+      assert.match(
+        result.dtsText,
+        /Child\$ChangeEventParameters extends Parent\$ChangeEventParameters/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Previously, all properties in generated $Xxx$YyyEventParameters interfaces were unconditionally forced to optional (?), regardless of their actual "optional" value in the api.json source data.

Now the generator respects each parameter's optional field by default:
- optional: false → required (no ?)
- optional: true or undefined → optional (?)

For events whose parameter optionality has not yet been verified in the OpenUI5/SAPUI5 sources, a new "eventsWithAllParamsOptional" directive (string[] in .dtsgenrc) preserves the legacy all-optional behavior. Format: "fully.qualified.ClassName:eventName"

Changes:

- generate-from-objects.ts: Add eventsWithAllParamsOptional to Directives.

- generate.ts: Initialize the new directive field.

- json-fixer.ts: Pass directives to addEventParameterInterfaces(). Add "events" to mapLikeProperties so .dtsgenrc overlays can target individual events by name.

- json-event-parameter-interfaces.ts: Invert buildProperties() to respect source data by default; only force all-optional when the event is in the eventsWithAllParamsOptional deny-list. Log a warning when a parameter has no "optional" value (unexpected edge case).

- Regenerated snapshot .d.ts files (parameters with optional: false now appear as required).

Needed for https://github.com/UI5/typescript/issues/529