### PR TITLE
fix(dts-generator): align module option with moduleResolution for TS6

### DIFF
--- a/packages/dts-generator/src/runCheck.ts
+++ b/packages/dts-generator/src/runCheck.ts
@@ -56,7 +56,7 @@ async function main() {
       noImplicitAny: true,
       strict: true,
       target: ScriptTarget.ES2015,
-      module: ModuleKind.ES2015,
+      module: ModuleKind.Node16,
       moduleResolution: ModuleResolutionKind.Node16,
     },
   });


### PR DESCRIPTION
TypeScript 6 requires module to be set to Node16 when moduleResolution is Node16. The previous ES2015 value was valid in TS5 but now causes a config diagnostic that cascades into spurious type errors (JQuery namespace, QUnit.Assert) during the check-compile phase.