### PR TITLE
fix(dts-generator): fix runCheck for TS6 compatibility

### DIFF
--- a/packages/dts-generator/src/runCheck.ts
+++ b/packages/dts-generator/src/runCheck.ts
@@ -3,7 +3,7 @@ const log = getLogger("@ui5/dts-generator/runCheck");
 import esMain from "es-main";
 
 import * as path from "path";
-import { promises as fsp } from "fs";
+import { promises as fsp, readdirSync, readFileSync } from "fs";
 const readdir = fsp.readdir;
 
 import {
@@ -48,6 +48,53 @@ async function main() {
 
   const dtsFiles = await findFiles(dtsDir, "d.ts");
 
+  // TS6 no longer auto-includes @types packages; discover which ones are declared
+  // as dependencies and walk up from CWD to find where they're installed.
+  const declaredTypes = new Set<string>();
+  let dir = process.cwd();
+  while (true) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf8"),
+      );
+      for (const deps of [pkg.dependencies, pkg.devDependencies]) {
+        if (deps) {
+          for (const name of Object.keys(deps)) {
+            if (name.startsWith("@types/")) {
+              declaredTypes.add(name.slice("@types/".length));
+            }
+          }
+        }
+      }
+      break;
+    } catch {
+      // no package.json at this level
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  const typeRoots: string[] = [];
+  const types = new Set<string>();
+  dir = process.cwd();
+  while (true) {
+    const candidate = path.join(dir, "node_modules", "@types");
+    try {
+      for (const entry of readdirSync(candidate, { withFileTypes: true })) {
+        if (entry.isDirectory() && declaredTypes.has(entry.name)) {
+          types.add(entry.name);
+        }
+      }
+      typeRoots.push(candidate);
+    } catch {
+      // doesn't exist at this level
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
   log.verbose(`Running a compile check for ${dtsFiles}`);
   const success = checkCompile({
     dependencyFiles: dtsFiles,
@@ -56,8 +103,9 @@ async function main() {
       noImplicitAny: true,
       strict: true,
       target: ScriptTarget.ES2015,
-      module: ModuleKind.Node16,
-      moduleResolution: ModuleResolutionKind.Node16,
+      module: ModuleKind.ESNext,
+      moduleResolution: ModuleResolutionKind.Bundler,
+      ...(typeRoots.length > 0 && { typeRoots, types: [...types] }),
     },
   });
 

--- a/test-packages/openui5-snapshot-test/package.json
+++ b/test-packages/openui5-snapshot-test/package.json
@@ -19,8 +19,9 @@
     "@types/qunit": "2.5.4"
   },
   "scripts": {
-    "ci": "npm-run-all test",
+    "ci": "npm-run-all test dts:run-check",
     "test": "mocha \"./test/**/*spec.js\"",
+    "dts:run-check": "node ../../packages/dts-generator/dist/runCheck.js output-dts",
     "re-generate": "npm-run-all sdk:* dts:*",
     "sdk:download": "node ./lib/download-sdk.js",
     "sdk:format": "prettier --write \"input-sdk/*.json\"",


### PR DESCRIPTION
TS6 introduced three breaking changes that affected runCheck:

1. moduleResolution "Node16" rejects bare-specifier ambient module declarations (declare module "sap/ui/core/Control") — switched to module: ESNext + moduleResolution: Bundler which supports them.

2. The default types list is now empty, so @types packages are no longer auto-included — added discovery logic that reads declared @types/* from the nearest package.json and walks up from CWD to locate them in potentially hoisted node_modules directories.

3. In monorepo/workspace setups the walk-up could find unrelated @types packages (e.g. @types/openui5) that conflict with the .d.ts files being checked — scoped discovery to only declared dependencies.