### PR TITLE
Exclude api/ directory from Jekyll processing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 theme: jekyll-theme-slate
 title: UI5 & TypeScript
 description: The central entry point for everything TypeScript-related in SAPUI5/OpenUI5
+exclude: [api, scripts, node_modules, package.json, package-lock.json]


### PR DESCRIPTION
Prepares for the TypeScript API reference pages that will be generated and pushed by a GitHub Actions workflow. Jekyll must not process the static HTML in api/.