### PR TITLE
feat: add sitemap index and static site sitemap

### DIFF
--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://ui5.github.io/typescript/</loc></url>
-  <url><loc>https://ui5.github.io/typescript/releasenotes</loc></url>
-  <url><loc>https://ui5.github.io/typescript/faq</loc></url>
+  <url><loc>https://ui5.github.io/typescript/releasenotes.html</loc></url>
+  <url><loc>https://ui5.github.io/typescript/faq.html</loc></url>
 </urlset>

--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -3,4 +3,5 @@
   <url><loc>https://ui5.github.io/typescript/</loc></url>
   <url><loc>https://ui5.github.io/typescript/releasenotes.html</loc></url>
   <url><loc>https://ui5.github.io/typescript/faq.html</loc></url>
+  <url><loc>https://ui5.github.io/typescript/api/llms.txt</loc></url>
 </urlset>

--- a/sitemap-site.xml
+++ b/sitemap-site.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://ui5.github.io/typescript/</loc></url>
+  <url><loc>https://ui5.github.io/typescript/releasenotes</loc></url>
+  <url><loc>https://ui5.github.io/typescript/faq</loc></url>
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://ui5.github.io/typescript/sitemap-site.xml</loc></sitemap>
+  <sitemap><loc>https://ui5.github.io/typescript/api/openui5/1.136/sitemap.xml</loc></sitemap>
+  <sitemap><loc>https://ui5.github.io/typescript/api/openui5/1.149/sitemap.xml</loc></sitemap>
+  <sitemap><loc>https://ui5.github.io/typescript/api/sapui5/1.149/sitemap.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
sitemap.xml is the sitemap index referenced from robots.txt. It links to sitemap-site.xml (static Jekyll pages) and all per-version API sitemaps. The workflow will regenerate sitemap.xml on each run to keep it in sync with available API versions.

sitemap-site.xml covers the handful of Jekyll-rendered pages (homepage, release notes, FAQ) and is manually maintained.